### PR TITLE
autogenerate year for copyright in footer

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -26,7 +26,7 @@
 
 # Footer
 - id: footerLegal.copyright
-  translation: "© Copyright 2017"
+  translation: "© Copyright"
 - id: footerLegal.by
   translation: "von "
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -26,7 +26,7 @@
 
 # Footer
 - id: footerLegal.copyright
-  translation: "© Copyright 2017"
+  translation: "© Copyright"
 - id: footerLegal.by
   translation: "by "
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
               </div>
             {{ else }}
               <div class="col-auto px-1">
-                {{- i18n "footerLegal.copyright" -}}
+                {{- i18n "footerLegal.copyright" -}} &nbsp;{{ now.Format "2006"}}
               </div>
               <div class="col-auto px-0">
                 {{- printf  " %s %s" (i18n "footerLegal.by") .Site.Params.name -}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**: Copyright Date is not autogenerated this PR fixes it using the Hugo date format.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #21 
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
