### PR TITLE
Fix background not settable on jumbotron

### DIFF
--- a/exampleSite/content/index/hero.md
+++ b/exampleSite/content/index/hero.md
@@ -4,7 +4,7 @@ fragment = "hero"
 date = "2016-09-07"
 lastmod = "2017-09-07"
 weight = 50
-#background = "dark" # can influence the text color
+background = "secondary" # can influence the text color
 particles = true
 
 title = "Syna Theme"

--- a/static/css/syna.css
+++ b/static/css/syna.css
@@ -10,6 +10,10 @@
   border-radius: 0rem;
 }
 
+.jumbotron {
+  border-radius: 0rem !important;
+}
+
 .overlay {
   position: relative;
   z-index: 100;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
No background added to hero fragment enable background on the jumbotron

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #37 

**Special notes for your reviewer**:
Not sure if this is a fix is this close to the solution required?
