### PR TITLE
Set background on jumbotron hero fragment 

### DIFF
--- a/exampleSite/content/about/hero.md
+++ b/exampleSite/content/about/hero.md
@@ -4,7 +4,7 @@ fragment = "hero"
 date = "2016-09-07"
 lastmod = "2017-09-07"
 weight = 50
-background = "secondary" # can influence the text color
+background = "dark" # can influence the text color
 particles = true
 
 title = "Syna Theme"

--- a/exampleSite/content/index/hero.md
+++ b/exampleSite/content/index/hero.md
@@ -4,7 +4,7 @@ fragment = "hero"
 date = "2016-09-07"
 lastmod = "2017-09-07"
 weight = 50
-#background = "dark" # can influence the text color
+background = "dark" # can influence the text color
 particles = true
 
 title = "Syna Theme"

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -4,9 +4,13 @@
 
 <header>
   {{ with $hero.header }}
-    <div class="jumbotron text-center header-image mb-0">
+    <div class="jumbotron text-center header-image mb-0
+     {{- printf " bg-%s" $bg -}}
+    ">
   {{ else }}
-    <div class="jumbotron text-center mb-0">
+    <div class="jumbotron text-center mb-0
+     {{- printf " bg-%s" $bg -}}
+    ">
   {{ end }}
   {{ if $hero.particles }}
     <div id="particles-js"></div>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**: 
No background added to hero fragment enable background on the jumbotron

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #37  
