### PR TITLE
Remove d-none class from error message containers in contact form

### DIFF
--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -56,7 +56,7 @@
                       data-validation-error-msg-container="#name-error"
                       placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}"
                       required>
-                    <div class="px-2 d-none" id="name-error"></div>
+                    <div class="px-2" id="name-error"></div>
                   </div>
                 {{ end }}
                 {{ with $contact.fields.email }}
@@ -71,7 +71,7 @@
                       data-validation-error-msg-container="#email-error"
                       placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}"
                       required>
-                    <div class="px-2 d-none" id="email-error"></div>
+                    <div class="px-2" id="email-error"></div>
                   </div>
                 {{ end }}
                 {{ with $contact.fields.phone }}
@@ -87,7 +87,7 @@
                       data-validation-error-msg="{{ .error | default (i18n "contact.defaultPhoneError") }}"
                       data-validation-error-msg-container="#phone-error"
                       placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}">
-                    <div class="px-2 d-none" id="phone-error"></div>
+                    <div class="px-2" id="phone-error"></div>
                   </div>
                 {{ end }}
               </div>
@@ -106,7 +106,7 @@
                       placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}"
                       rows="4"
                       required></textarea>
-                    <div class="px-2 d-none" id="message-error"></div>
+                    <div class="px-2" id="message-error"></div>
                   </div>
                 {{ end }}
               </div>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Fixes an issue where contact form error messages where not shown

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #47 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
