### PR TITLE
Replace self_link with file name of each resource

### DIFF
--- a/exampleSite/content/index/awesome-team.md
+++ b/exampleSite/content/index/awesome-team.md
@@ -4,7 +4,6 @@ fragment = "member"
 date = "2017-10-17"
 weight = 900
 #background = "dark"
-self_link = "member-fragment"
 
 title = "Member Fragment"
 subtitle = "Highly motivated Gophers"

--- a/exampleSite/content/index/button_download.md
+++ b/exampleSite/content/index/button_download.md
@@ -4,7 +4,6 @@ fragment = "buttons"
 date = "2016-09-07"
 weight = 700
 background = "secondary"
-self_link = "buttons-fragment-secondary"
 
 title = "Buttons Fragment"
 subtitle = "Using secondary background"

--- a/exampleSite/content/index/buttons.md
+++ b/exampleSite/content/index/buttons.md
@@ -4,7 +4,6 @@ fragment = "buttons"
 date = "2016-09-07"
 weight = 720
 background = "primary"
-self_link = "buttons-fragment"
 
 title = "Buttons Fragment"
 subtitle = "Using primary background"

--- a/exampleSite/content/index/buttons_contribute.md
+++ b/exampleSite/content/index/buttons_contribute.md
@@ -4,7 +4,6 @@ fragment = "buttons"
 date = "2016-09-07"
 weight = 710
 #background = ""
-self_link = "button-fragment"
 
 title = "Buttons Fragment"
 #subtitle = ""

--- a/exampleSite/content/index/contact.md
+++ b/exampleSite/content/index/contact.md
@@ -4,7 +4,6 @@ fragment = "contact"
 date = "2017-09-10"
 weight = 1100
 #background = "light"
-self_link = "contact-fragment"
 form_name = "defaultContact"
 
 title = "Contact fragment"

--- a/exampleSite/content/index/embed_subscribe.md
+++ b/exampleSite/content/index/embed_subscribe.md
@@ -4,7 +4,6 @@ fragment = "embed"
 date = "2017-10-07"
 weight = 1050
 background = "light"
-self_link = "contact"
 form_name = "subscribe"
 
 #title = ""

--- a/exampleSite/content/index/embed_video.md
+++ b/exampleSite/content/index/embed_video.md
@@ -4,7 +4,6 @@ fragment = "embed"
 date = "2017-09-09"
 weight = 800
 background = "secondary"
-self_link = "video-fragment"
 
 title = "Embed Fragment"
 subtitle = "Easily embed media (videos, iframes etc.)"

--- a/exampleSite/content/index/item_button-center.md
+++ b/exampleSite/content/index/item_button-center.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 420
 background = "dark"
-self_link = "item-fragment-button-center"
 align = "center"
 
 title = "Item Fragment Button Center"

--- a/exampleSite/content/index/item_button-left.md
+++ b/exampleSite/content/index/item_button-left.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 410
 #background = ""
-self_link = "item-fragment-button-left"
 align = "left"
 
 title = "Item Fragment Button Left"

--- a/exampleSite/content/index/item_button-right.md
+++ b/exampleSite/content/index/item_button-right.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 400
 background = "dark"
-self_link = "item-fragment-button-right"
 align = "right"
 
 title = "Item Fragment Button Right"

--- a/exampleSite/content/index/item_icon-center.md
+++ b/exampleSite/content/index/item_icon-center.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 310
 background = "secondary"
-self_link = "item-fragment-icon-center"
 align = "center"
 
 title = "Item Fragment Icon Center"

--- a/exampleSite/content/index/item_icon-left.md
+++ b/exampleSite/content/index/item_icon-left.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 300
 #background = ""
-self_link = "item-fragment-icon-left"
 align = "left"
 
 title = "Item Fragment Icon Left"

--- a/exampleSite/content/index/item_image-button-left.md
+++ b/exampleSite/content/index/item_image-button-left.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 360
 background = "light"
-self_link = "item-fragment-image-button-left"
 align = "left"
 
 title = "Item Fragment Image Button Left"

--- a/exampleSite/content/index/item_image-center.md
+++ b/exampleSite/content/index/item_image-center.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 350
 background = "secondary"
-self_link = "item-fragment-image-center"
 align = "center"
 
 title = "Item Fragment Image Center"

--- a/exampleSite/content/index/item_image-only.md
+++ b/exampleSite/content/index/item_image-only.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 330
 background = "secondary"
-self_link = "item-fragment-image-only-center"
 align = "center"
 
 title = "Item Fragment Image Only"

--- a/exampleSite/content/index/item_image-right.md
+++ b/exampleSite/content/index/item_image-right.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 320
 background = "dark"
-self_link = "item-fragment-image-right"
 align = "right"
 
 title = "Item Fragment Image Right"

--- a/exampleSite/content/index/item_image-table-left.md
+++ b/exampleSite/content/index/item_image-table-left.md
@@ -4,7 +4,6 @@ fragment = "item"
 date = "2017-10-04"
 weight = 340
 #background = ""
-self_link = "item-fragment-image-table-left"
 align = "left"
 
 title = "Item Fragment Image Table Left"

--- a/exampleSite/content/index/items.md
+++ b/exampleSite/content/index/items.md
@@ -4,7 +4,6 @@ fragment = "items"
 date = "2017-10-04"
 weight = 100
 #background = "dark"
-self_link = "items-fragment"
 
 title = "Items Fragment"
 subtitle= "Column based items with icons"

--- a/exampleSite/content/index/items_only.md
+++ b/exampleSite/content/index/items_only.md
@@ -4,7 +4,6 @@ fragment = "items"
 date = "2017-10-04"
 weight = 110
 background = "dark"
-self_link = "items-fragment-only"
 
 #title = ""
 #subtitle = ""

--- a/exampleSite/content/index/logos.md
+++ b/exampleSite/content/index/logos.md
@@ -4,7 +4,6 @@ fragment = "logos"
 date = "2017-09-09"
 weight = 1000
 #background = ""
-self_link = "tools"
 
 title = "Logo Fragment"
 subtitle = "Even linking is possible"

--- a/exampleSite/content/index/logos_only.md
+++ b/exampleSite/content/index/logos_only.md
@@ -4,7 +4,6 @@ fragment = "logos"
 date = "2017-09-09"
 weight = 1010
 background = "dark"
-self_link = "users"
 
 #title = ""
 #subtitle = ""

--- a/exampleSite/content/index/sample-custom-fragment.md
+++ b/exampleSite/content/index/sample-custom-fragment.md
@@ -3,5 +3,4 @@ fragment = "sample-custom-fragment"
 #disabled = false
 date = "2017-09-09"
 weight = 1000
-self_link = "sample-custom-fragment"
 +++

--- a/exampleSite/content/index/table.md
+++ b/exampleSite/content/index/table.md
@@ -4,7 +4,6 @@ fragment = "table"
 date = "2017-10-10"
 weight = 500
 background = "light"
-self_link = "table-fragment"
 
 title = "Table Fragment"
 subtitle= "Tables are responsive by default"

--- a/exampleSite/layouts/partials/fragments/sample-custom-fragment.html
+++ b/exampleSite/layouts/partials/fragments/sample-custom-fragment.html
@@ -1,7 +1,8 @@
 {{ $fragment := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $bg := $fragment.background | default "secondary" }}
 
-<section id="{{ $fragment.self_link }}">
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/buttons.html
+++ b/layouts/partials/fragments/buttons.html
@@ -1,8 +1,9 @@
 {{ $buttons := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Buttons -->" | safeHTML }}
 {{ $bg := $buttons.background | default "white" }}
 
-<section {{ with $buttons.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -1,8 +1,9 @@
 {{ $contact := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Contact -->" | safeHTML }}
 {{ $bg := $contact.background | default "secondary" }}
 
-<section id="{{ $contact.self_link }}">
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/content-single.html
+++ b/layouts/partials/fragments/content-single.html
@@ -1,9 +1,10 @@
 {{ $self := .self }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $content_single := .self.Params }}
 {{ "<!-- Content -->" | safeHTML }}
 {{ $bg :=  $content_single.background | default "light"}}
 
-<section>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/content-split.html
+++ b/layouts/partials/fragments/content-split.html
@@ -1,9 +1,10 @@
 {{ $self := .self }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $content_split := .self.Params }}
 {{ "<!-- Content -->" | safeHTML }}
 {{ $bg := $content_split.background | default "light"}}
 
-<section>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/copyright.html
+++ b/layouts/partials/fragments/copyright.html
@@ -1,11 +1,12 @@
 {{ $copyright := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $menus := .menus }}
 {{ "<!-- Copyright -->" | safeHTML }}
 {{ $bg := $copyright.background | default "secondary"}}
 
 <footer class="overlay container-fluid
   {{- printf " bg-%s" $bg -}}
-">
+" id="{{ $name }}">
   <div class="container">
     <div class="row py-3">
       <div class="col-md">

--- a/layouts/partials/fragments/embed.html
+++ b/layouts/partials/fragments/embed.html
@@ -1,10 +1,11 @@
 {{ $embed := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Embed -->" | safeHTML }}
 {{ $bg := $embed.background | default "white" }}
 {{ $ratio := $embed.ratio | default "4by3" }}
 {{ $size := $embed.size | default "75" }}
 
-<section {{ with $embed.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -1,11 +1,12 @@
 {{ $footer := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $menus := .menus }}
 {{ "<!-- Footer -->" | safeHTML }}
 {{ $bg := $footer.background | default "dark"}}
 
 <div class="overlay container-fluid
   {{- printf " bg-%s" $bg -}}
-">
+" id="{{ $name }}">
   <div class="container py-5">
     <div class="row">
       <div class="col-md m-2

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -1,15 +1,14 @@
 {{ $hero := .self.Params }}
-{{ $name := .self.Name }}
-{{ $name := replace $name "/index.md" "" }}
-{{ $name := strings.TrimSuffix ".md" $name }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ $path := .self.File.Path }}
 {{ $path := replace $path "/index.md" "" }}
 {{ $path := strings.TrimSuffix ".md" $path }}
-{{ $page_path := replace $path (printf "/%s" $name) "" }} {{ $tmp_full := .tmp_full }}
+{{ $page_path := replace $path (printf "/%s" $name) "" }}
+{{ $tmp_full := .tmp_full }}
 {{ "<!-- hero -->" | safeHTML }}
 {{ $bg := $hero.background | default "secondary" }}
 
-<header>
+<header id="{{ $name }}">
   {{ if $hero.header }}
     <div class="jumbotron text-center header-image mb-0
      {{- printf " bg-%s" $bg -}}

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -1,9 +1,10 @@
 {{ $item := .self.Params}}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Item -->" | safeHTML }}
 {{ $bg := $item.background | default "light"}}
 {{ $align := $item.align | default "center" }}
 
-<section {{ with $item.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -1,12 +1,10 @@
 {{ $itemf := .self.Params }}
-{{ $name := .self.Name }}
-{{ $name_t := strings.TrimSuffix ".md" $name }}
-{{ $items:= .resources.Match (printf "%s/*" $name_t) }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
+{{ $items := .resources.Match (printf "%s/*" $name) }}
 {{ "<!-- Items -->" | safeHTML }}
 {{ $bg := $itemf.background | default "light"}}
 
-
-<section {{ with $itemf.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -1,8 +1,9 @@
 {{ $logos := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Logos -->" | safeHTML }}
 {{ $bg := $logos.background | default "white" }}
 
-<section {{ with $logos.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -1,11 +1,10 @@
 {{ $memberf := .self.Params }}
-{{ $name := .self.Name }}
-{{ $name_t := strings.TrimSuffix ".md" $name }}
-{{ $members := .resources.Match (printf "%s/*" $name_t) }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
+{{ $members := .resources.Match (printf "%s/*" $name) }}
 {{ "<!-- Member -->" | safeHTML }}
 {{ $bg := $memberf.background | default "light"}}
 
-<section {{ with $memberf.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -1,4 +1,5 @@
 {{ $nav := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Nav -->" | safeHTML }}
 {{ $bg := $nav.background | default "dark" }}
 
@@ -9,7 +10,7 @@
   {{- else -}}
     {{- printf " navbar-%s" "dark" -}}
   {{- end -}}
-">
+" id="{{ $name }}">
   <div class="container">
     {{ if $nav.branding.logo }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -1,9 +1,10 @@
 {{ $table := .self.Params }}
+{{ $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") }}
 {{ "<!-- Item -->" | safeHTML }}
 {{ $bg := $table.background | default "light"}}
 {{ $align := $table.align | default "center" }}
 
-<section {{ with $table.self_link }}id="{{ . }}"{{ end }}>
+<section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Replaces `self_link` in each fragment with the resource controlling the fragment file name.

**Which issue this PR fixes**:
fixes #129 

**Release note**:
```release-note
BREAKING: `self_link` is deprecated. Replaced with resource file name.
```
