### PR TITLE
Add webpack build command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Michael Grosser (stp-ip)",
   "license": "Apache",
   "scripts": {
-    "start": "webpack --watch --progress"
+    "start": "webpack --watch --progress",
+    "build": "webpack --progress"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
**What this PR does / why we need it**:
There was no build command in package.json for building static files. This PR fixes that.
