### PR TITLE
Add resource fallthrough to all fragments with image

### DIFF
--- a/exampleSite/content/index/awesome-team/donald.md
+++ b/exampleSite/content/index/awesome-team/donald.md
@@ -2,7 +2,7 @@
   title = "Tiny Gopher 4"
   weight = 30
   joined = "2017-10-17"
-  image = "tinygopher.png"
+  image = "member/tinygopher.png"
   position = "Gopherineer"
 
   lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"

--- a/exampleSite/content/index/awesome-team/ella.md
+++ b/exampleSite/content/index/awesome-team/ella.md
@@ -2,7 +2,7 @@
   title = "Huge Gopher"
   weight = 0
   joined = "2017-10-17"
-  image = "hugegopher.png"
+  image = "member/hugegopher.png"
   position = "Lead Gopherineer"
 
   reports_to = "CTO"

--- a/exampleSite/content/index/awesome-team/gopher.md
+++ b/exampleSite/content/index/awesome-team/gopher.md
@@ -2,7 +2,7 @@
   title = "Tiny Gopher"
   weight = 10
   joined = "2017-10-17"
-  image = "tinygopher.png"
+  image = "member/tinygopher.png"
   position = "Gopherineer"
 
   reports_to = "Lead Gophineer"

--- a/exampleSite/content/index/awesome-team/hector.md
+++ b/exampleSite/content/index/awesome-team/hector.md
@@ -2,7 +2,7 @@
   title = "Tiny Gopher 5"
   weight = 30
   joined = "2017-10-17"
-  image = "tinygopher.png"
+  image = "member/tinygopher.png"
 
   lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 

--- a/exampleSite/content/index/awesome-team/nancy.md
+++ b/exampleSite/content/index/awesome-team/nancy.md
@@ -2,7 +2,7 @@
   title = "Tiny Gopher 2"
   weight = 20
   joined = "2017-10-17"
-  image = "tinygopher.png"
+  image = "member/tinygopher.png"
   position = "Gopherineer"
 
   reports_to = "Lead Gophineer"

--- a/exampleSite/content/index/awesome-team/yoda.md
+++ b/exampleSite/content/index/awesome-team/yoda.md
@@ -2,7 +2,7 @@
   title = "Tiny Gopher 3"
   weight = 30
   joined = "2017-10-17"
-  image = "tinygopher.png"
+  image = "member/tinygopher.png"
   position = "Gopherineer"
 
   reports_to = "Lead Gophineer"

--- a/exampleSite/content/index/item_image-button-left.md
+++ b/exampleSite/content/index/item_image-button-left.md
@@ -13,7 +13,7 @@ title = "Item Fragment Image Button Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+image = "row/screenshot.png"
 
 [[buttons]]
   text = "Button"

--- a/exampleSite/content/index/item_image-center.md
+++ b/exampleSite/content/index/item_image-center.md
@@ -13,7 +13,7 @@ title = "Item Fragment Image Center"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+image = "row/screenshot.png"
 +++
 
 

--- a/exampleSite/content/index/item_image-only.md
+++ b/exampleSite/content/index/item_image-only.md
@@ -13,5 +13,5 @@ title = "Item Fragment Image Only"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+image = "row/screenshot.png"
 +++

--- a/exampleSite/content/index/item_image-right.md
+++ b/exampleSite/content/index/item_image-right.md
@@ -13,7 +13,7 @@ subtitle= "Easily right align the item fragment even with an image"
 pre = "Awesome screenshot"
 post = "Showcasing Syna"
 
-image = "screenshot.png"
+image = "row/screenshot.png"
 +++
 
 Easily left align the item fragment even with an image and buttons at the same time.

--- a/exampleSite/content/index/item_image-table-left.md
+++ b/exampleSite/content/index/item_image-table-left.md
@@ -13,7 +13,7 @@ title = "Item Fragment Image Table Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+image = "row/screenshot.png"
 
 [header]
   [[header.values]]

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -1,9 +1,5 @@
 {{- $hero := .self.Params -}}
 {{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
-{{- $path := .self.File.Path -}}
-{{- $path := replace $path "/index.md" "" -}}
-{{- $path := strings.TrimSuffix ".md" $path -}}
-{{- $page_path := replace $path (printf "/%s" $name) "" -}}
 {{- $tmp_full := .tmp_full -}}
 {{ "<!-- hero -->" | safeHTML }}
 {{- $bg := $hero.background | default "secondary" }}
@@ -22,25 +18,27 @@
   {{- end -}}
 
   {{- if $hero.logo -}}
+    {{- $path := .self.File.Path -}}
+    {{- $path := replace $path "/index.md" "" -}}
+    {{- $path := strings.TrimSuffix ".md" $path -}}
+    {{- $page_path := replace $path (printf "/%s" $name) "" -}}
     {{/* fallback to global resource */}}
     {{- $tmp_full.Scratch.Set "image" (printf "images/%s" $hero.logo.image) -}}
-    {{- range .resources.ByType "image" -}}
 
-      {{/* try for page specific resource */}}
-      {{- $location := (printf "%s/%s" $page_path $hero.logo.image) -}}
-      {{- if (fileExists $location) -}}
-        {{/* special case index: trim index/ from url */}}
-        {{- $location := strings.TrimPrefix "index/" $location -}}
-        {{- $tmp_full.Scratch.Set "image" $location -}}
-      {{- end -}}
+    {{/* try for page specific resource */}}
+    {{- $location := (printf "%s/%s" $page_path $hero.logo.image) -}}
+    {{- if (fileExists (printf "content/%s" $location)) -}}
+      {{/* special case index: trim index/ from url */}}
+      {{- $location := strings.TrimPrefix "index/" $location -}}
+      {{- $tmp_full.Scratch.Set "image" $location -}}
+    {{- end -}}
 
-      {{/* try for fragment specific resource */}}
-      {{- $location := (printf "%s/%s" $path $hero.logo.image) -}}
-      {{- if (fileExists $location) -}}
-        {{/* special case index: trim index/ from url */}}
-        {{- $location := strings.TrimPrefix "index/" $location -}}
-        {{- $tmp_full.Scratch.Set "image" $location -}}
-      {{- end -}}
+    {{/* try for fragment specific resource */}}
+    {{- $location := (printf "%s/%s" $path $hero.logo.image) -}}
+    {{- if (fileExists (printf "content/%s" $location)) -}}
+      {{/* special case index: trim index/ from url */}}
+      {{- $location := strings.TrimPrefix "index/" $location -}}
+      {{- $tmp_full.Scratch.Set "image" $location -}}
     {{- end -}}
     {{- with $hero.logo }}
       <div class="row justify-content-center align-items-start">

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -1,8 +1,35 @@
 {{- $item := .self.Params -}}
 {{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
+{{- $tmp_full := .tmp_full -}}
 {{ "<!-- Item -->" | safeHTML }}
 {{- $bg := $item.background | default "light" -}}
-{{- $align := $item.align | default "center" }}
+{{- $align := $item.align | default "center" -}}
+
+{{- if $item.image -}}
+  {{- $image := $item.image -}}
+  {{- $path := .self.File.Path -}}
+  {{- $path := replace $path "/index.md" "" -}}
+  {{- $path := strings.TrimSuffix ".md" $path -}}
+  {{- $page_path := replace $path (printf "/%s" $name) "" -}}
+  {{/* fallback to global resource */}}
+  {{- $tmp_full.Scratch.Set "image" (printf "images/%s" $image) -}}
+
+  {{/* try for page specific resource */}}
+  {{- $location := (printf "%s/%s" $page_path $image) -}}
+  {{- if (fileExists (printf "content/%s" $location)) -}}
+    {{/* special case index: trim index/ from url */}}
+    {{- $location := strings.TrimPrefix "index/" $location -}}
+    {{- $tmp_full.Scratch.Set "image" $location -}}
+  {{- end -}}
+
+  {{/* try for fragment specific resource */}}
+  {{- $location := (printf "%s/%s" $path $image) -}}
+  {{- if (fileExists (printf "content/%s" $location)) -}}
+    {{/* special case index: trim index/ from url */}}
+    {{- $location := strings.TrimPrefix "index/" $location -}}
+    {{- $tmp_full.Scratch.Set "image" $location -}}
+  {{- end -}}
+{{- end }}
 <section id="{{ $name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
@@ -97,8 +124,7 @@
                     <i class="fas {{ $item.icon }} fa-stack-1x fa-inverse"></i>
                   </span>
                 {{- else if $item.image -}}
-                  {{- $url := printf "images/row/%s" $item.image }}
-                  <img src="{{ $url | absURL }}" class="img-fluid p-2" alt="{{ $item.name }}">
+                  <img src="{{ $tmp_full.Scratch.Get "image" | absURL }}" class="img-fluid p-2" alt="{{ $item.name }}">
                 {{- end -}}
                 {{- if and (not $item.icon) (not $item.image) -}}
                   {{- range $item.buttons }}
@@ -281,9 +307,8 @@
                 </span>
               </div>
             {{- else if $item.image }}
-              {{- $url := printf "images/row/%s" $item.image }}
               <div class="col-12 text-center d-none d-lg-inline">
-                <img src="{{ $url | absURL }}" class="img-fluid p-2" alt="{{ $item.name }}">
+                <img src="{{ $tmp_full.Scratch.Get "image" | absURL }}" class="img-fluid p-2" alt="{{ $item.name }}">
               </div>
             {{- end -}}
             {{- if and (not $item.icon) (not $item.image) }}

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -39,8 +39,8 @@
         </div>
       {{- end }}
       <div class="row justify-content-center align-items-start">
-         {{- range $items -}}
-           {{- $items:= .Params }}
+        {{- range $items -}}
+          {{- $items:= .Params }}
           <div class="col-md-4 text-center">
             <span class="fa-stack fa-3x m-2">
               <i class="fas fa-circle fa-stack-2x

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -1,6 +1,7 @@
 {{- $memberf := .self.Params -}}
 {{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
-{{- $members := .resources.Match (printf "%s/*" $name) -}}
+{{- $members := .resources.Match (printf "%s/*.md" $name) -}}
+{{- $tmp_full := .tmp_full -}}
 {{ "<!-- Member -->" | safeHTML }}
 {{- $bg := $memberf.background | default "light" }}
 <section id="{{ $name }}">
@@ -39,11 +40,36 @@
         </div>
       {{- end }}
       <div class="row justify-content-center align-items-start">
+        {{- $path := .self.File.Path -}}
+        {{- $path := replace $path "/index.md" "" -}}
+        {{- $path := strings.TrimSuffix ".md" $path -}}
+        {{- $page_path := replace $path (printf "/%s" $name) "" -}}
         {{- range $members -}}
-          {{- $member := .Params }}
+          {{- $member := .Params -}}
+
+          {{- $image := $member.image -}}
+          {{- $tmp_full.Scratch.Delete "image" -}}
+          {{/* fallback to global resource */}}
+          {{- $tmp_full.Scratch.Set "image" (printf "images/%s" $image) -}}
+        
+          {{/* try for page specific resource */}}
+          {{- $location := (printf "%s/%s" $page_path $image) -}}
+          {{- if (fileExists (printf "content/%s" $location)) -}}
+            {{/* special case index: trim index/ from url */}}
+            {{- $location := strings.TrimPrefix "index/" $location -}}
+            {{- $tmp_full.Scratch.Set "image" $location -}}
+          {{- end -}}
+        
+          {{/* try for fragment specific resource */}}
+          {{- $location := (printf "%s/%s" $path $image) -}}
+          {{- if (fileExists (printf "content/%s" $location)) -}}
+            {{/* special case index: trim index/ from url */}}
+            {{- $location := strings.TrimPrefix "index/" $location -}}
+            {{- $tmp_full.Scratch.Set "image" $location -}}
+          {{- end }}
           <div class="col-lg-4 col-md-6 col-sm-12 pt-3 pb-5 text-left text-sm-center">
             <div class="text-center m-2">
-              <img src="/images/member/{{ $member.image }}" class="img-fluid rounded-circle w-75 border
+              <img src="{{ $tmp_full.Scratch.Get "image" | absURL }}" class="img-fluid rounded-circle w-75 border
                 {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                   {{- printf " border-%s" "dark" -}}
                 {{- else -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add resource fallthough to member and item fragment and fix an issue with it in hero fragment

**Which issue this PR fixes**:
fixes #124 

**Special notes for your reviewer**:
The fix is that the `fileExists` function does not check exactly where the file is. With this fix it looks in the `content` directory for the file to see if the file is available in page or in the fragment directory.

**Release note**:
```release-note
Add resource fallthrough (Hugo style file matching, you can now choose `image.png` and that file is checked in fragment directory, then in page directory and finally in `static/images` directory for that file.)
```
