### PR TITLE
Centralized fragment name generation

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -31,7 +31,8 @@
 
   {{- range sort ($.Scratch.Get "fragments" | default slice) "Params.weight" -}}
     {{- if and (not .Params.disabled) (isset .Params "fragment") -}}
-      {{- partial (print "fragments/" .Params.fragment ".html") (dict "root" $ "Site" $.Site "resources" $.Resources "self" . "Params" .Params ) -}}
+      {{- $name := strings.TrimSuffix ".md" (replace .Name "/index.md" "") -}}
+      {{- partial (print "fragments/" .Params.fragment ".html") (dict "root" $ "Site" $.Site "resources" $.Resources "self" . "Params" .Params "Name" $name) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/fragments/buttons.html
+++ b/layouts/partials/fragments/buttons.html
@@ -1,8 +1,7 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "white" }}
 
 {{ "<!-- Buttons -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -1,8 +1,7 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "secondary" }}
 
 {{ "<!-- Contact -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/content-single.html
+++ b/layouts/partials/fragments/content-single.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $self := .self -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Content -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/content-split.html
+++ b/layouts/partials/fragments/content-split.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $self := .self -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Content -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/copyright.html
+++ b/layouts/partials/fragments/copyright.html
@@ -1,11 +1,10 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $root := .root -}}
 {{- $bg := .Params.background | default "secondary" }}
 
 {{ "<!-- Copyright -->" | safeHTML }}
 <footer class="overlay container-fluid
   {{- printf " bg-%s" $bg -}}
-" id="{{ $name }}">
+" id="{{ .Name }}">
   <div class="container">
     <div class="row py-3">
       <div class="col-md">

--- a/layouts/partials/fragments/embed.html
+++ b/layouts/partials/fragments/embed.html
@@ -1,10 +1,9 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "white" -}}
 {{- $ratio := .Params.ratio | default "4by3" -}}
 {{- $size := .Params.size | default "75" }}
 
 {{ "<!-- Embed -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -1,10 +1,9 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "dark" }}
 
 {{ "<!-- Footer -->" | safeHTML }}
 <div class="overlay container-fluid
   {{- printf " bg-%s" $bg -}}
-" id="{{ $name }}">
+" id="{{ .Name }}">
   <div class="container py-5">
     <div class="row">
       <div class="col-md m-2

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -1,4 +1,3 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $root := .root -}}
 {{- $bg := .Params.background | default "secondary" }}
 
@@ -6,10 +5,10 @@
 {{- $path := .self.File.Path -}}
 {{- $path := replace $path "/index.md" "" -}}
 {{- $path := strings.TrimSuffix ".md" $path -}}
-{{- $page_path := replace $path (printf "/%s" $name) "" -}}
+{{- $page_path := replace $path (printf "/%s" .Name) "" -}}
 
 {{ "<!-- hero -->" | safeHTML }}
-<header id="{{ $name }}">
+<header id="{{ .Name }}">
   {{- if .Params.header }}
     <div class="jumbotron text-center header-image mb-0
      {{- printf " bg-%s" $bg -}}

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "light" -}}
 {{- $align := .Params.align | default "center" }}
 
 {{ "<!-- Item -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
-{{- $items := .resources.Match (printf "%s/*" $name) -}}
+{{- $items := .resources.Match (printf "%s/*" .Name) -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Items -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -1,8 +1,7 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "white" }}
 
 {{ "<!-- Logos -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
-{{- $members := .resources.Match (printf "%s/*" $name) -}}
+{{- $members := .resources.Match (printf "%s/*" .Name) -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Member -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -1,4 +1,3 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "dark" }}
 
 {{- "<!-- Navigation -->" | safeHTML -}}
@@ -9,7 +8,7 @@
   {{- else -}}
     {{- printf " navbar-%s" "dark" -}}
   {{- end -}}
-" id="{{ $name }}">
+" id="{{ .Name }}">
   <div class="container">
     {{- if .Params.branding.logo }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -1,9 +1,8 @@
-{{- $name := strings.TrimSuffix ".md" (replace .self.Name "/index.md" "") -}}
 {{- $bg := .Params.background | default "light" -}}
 {{- $align := .Params.align | default "center" }}
 
 {{ "<!-- Table -->" | safeHTML }}
-<section id="{{ $name }}">
+<section id="{{ .Name }}">
   <div class="overlay container-fluid
     {{- printf " bg-%s" $bg -}}
   ">


### PR DESCRIPTION
**What this PR does / why we need it**:
Within each fragment .Name is now provided by single.html.
Single.html is centrally setting the name to simplified value.
The simplification removes any index.md files or paths,
which shouldn't be necessary within each fragment.
