### PR TITLE
Don't include hero.js script when particls is disabled

### DIFF
--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -106,4 +106,6 @@
   {{- end }}
   </div>
 </header>
-<script src="{{ "hero.js" | relURL }}" defer async></script>
+{{- if .Params.particles }}
+  <script src="{{ "hero.js" | relURL }}" defer async></script>
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't include hero.js script when particls is disabled

**Which issue this PR fixes**:
fixes #172 