### PR TITLE
Rename all link variables to url to be more consistent

### DIFF
--- a/exampleSite/content/about/footer.md
+++ b/exampleSite/content/about/footer.md
@@ -11,7 +11,7 @@ menu_title = "Link Title"
   title = "Logo Title"
   image = "logo.svg"
   text = "Logo Subtext"
-  link = "#"
+  url = "#"
 +++
 
 #### Description Title

--- a/exampleSite/content/about/hero.md
+++ b/exampleSite/content/about/hero.md
@@ -17,16 +17,16 @@ header = "header.jpg"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "info" # primary, secondary, success, danger, warning, info, light, dark, link - default: primary
 
 [[buttons]]
   text = "Download"
-  link = "https://github.com/okkur/syna/releases"
+  url = "https://github.com/okkur/syna/releases"
   color = "primary"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "success"
 +++

--- a/exampleSite/content/dev/fallthrough/fragment/footer.md
+++ b/exampleSite/content/dev/fallthrough/fragment/footer.md
@@ -9,7 +9,7 @@ weight = 1200
   title = "Logo Title"
   image = "resource_logo.svg"
   text = "Logo Subtext"
-  link = "#"
+  url = "#"
 +++
 
 Content \o/

--- a/exampleSite/content/dev/fallthrough/fragment/logos/index.md
+++ b/exampleSite/content/dev/fallthrough/fragment/logos/index.md
@@ -11,5 +11,5 @@ title = "logos"
   name = "syna"
   weight = 10
   image = "resource_logo.svg"
-  #link = "#"
+  #url = "#"
 +++

--- a/exampleSite/content/dev/fallthrough/global/footer.md
+++ b/exampleSite/content/dev/fallthrough/global/footer.md
@@ -9,5 +9,5 @@ weight = 1200
   title = "Logo Title"
   image = "resource_logo.svg"
   text = "Logo Subtext"
-  link = "#"
+  url = "#"
 +++

--- a/exampleSite/content/dev/fallthrough/global/logos.md
+++ b/exampleSite/content/dev/fallthrough/global/logos.md
@@ -11,5 +11,5 @@ title = "logos"
   name = "syna"
   weight = 10
   image = "resource_logo.svg"
-  #link = "#"
+  #url = "#"
 +++

--- a/exampleSite/content/dev/fallthrough/page/footer.md
+++ b/exampleSite/content/dev/fallthrough/page/footer.md
@@ -9,7 +9,7 @@ weight = 1200
   title = "Logo Title"
   image = "resource_logo.svg"
   text = "Logo Subtext"
-  link = "#"
+  url = "#"
 +++
 
 Content \o/

--- a/exampleSite/content/dev/fallthrough/page/logos.md
+++ b/exampleSite/content/dev/fallthrough/page/logos.md
@@ -11,5 +11,5 @@ title = "logos"
   name = "syna"
   weight = 10
   image = "resource_logo.svg"
-  #link = "#"
+  #url = "#"
 +++

--- a/exampleSite/content/global/footer.md
+++ b/exampleSite/content/global/footer.md
@@ -11,7 +11,7 @@ menu_title = "Link Title"
   title = "Logo Title"
   image = "logo.svg"
   text = "Logo Subtext"
-  link = "#"
+  url = "#"
 +++
 
 #### Description Title

--- a/exampleSite/content/index/awesome-team/ella.md
+++ b/exampleSite/content/index/awesome-team/ella.md
@@ -15,7 +15,7 @@ scope = [
 
 [[icons]]
   icon = "fab fa-linkedin-in"
-  link = "#"
+  url = "#"
 +++
 
 Hugely huge Gopher

--- a/exampleSite/content/index/awesome-team/gopher.md
+++ b/exampleSite/content/index/awesome-team/gopher.md
@@ -15,11 +15,11 @@ scope = [
 
 [[icons]]
   icon = "fab fa-twitter"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-linkedin-in"
-  link = "#"
+  url = "#"
 +++
 
 Really tiny Gopher

--- a/exampleSite/content/index/awesome-team/hector.md
+++ b/exampleSite/content/index/awesome-team/hector.md
@@ -8,15 +8,15 @@ lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 
 [[icons]]
   icon = "fab fa-twitter"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-facebook"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-linkedin-in"
-  link = "#"
+  url = "#"
 +++
 
 Really tiny Gopher

--- a/exampleSite/content/index/awesome-team/nancy.md
+++ b/exampleSite/content/index/awesome-team/nancy.md
@@ -15,15 +15,15 @@ scope = [
 
 [[icons]]
   icon = "fab fa-twitter"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-facebook-f"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-linkedin-in"
-  link = "#"
+  url = "#"
 +++
 
 Really tiny Gopher

--- a/exampleSite/content/index/awesome-team/yoda.md
+++ b/exampleSite/content/index/awesome-team/yoda.md
@@ -15,15 +15,15 @@ scope = [
 
 [[icons]]
   icon = "fab fa-twitter"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-facebook-f"
-  link = "#"
+  url = "#"
 
 [[icons]]
   icon = "fab fa-linkedin-in"
-  link = "#"
+  url = "#"
 +++
 
 Really tiny Gopher

--- a/exampleSite/content/index/button_download.md
+++ b/exampleSite/content/index/button_download.md
@@ -10,6 +10,6 @@ subtitle = "Using secondary background"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "info"
 +++

--- a/exampleSite/content/index/buttons.md
+++ b/exampleSite/content/index/buttons.md
@@ -10,11 +10,11 @@ subtitle = "Using primary background"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "success" # primary, secondary, success, danger, warning, info, light, dark, link - default: primary
 
 [[buttons]]
   text = "Danger Button"
-  link = "#"
+  url = "#"
   color = "danger"
 +++

--- a/exampleSite/content/index/buttons_contribute.md
+++ b/exampleSite/content/index/buttons_contribute.md
@@ -10,16 +10,16 @@ title = "Buttons Fragment"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "outline-secondary" # primary, secondary, success, danger, warning, info, light, dark, link - default: primary
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "success"
 
 [[buttons]]
   text = "Long Button"
-  link = "#"
+  url = "#"
   color = "secondary" # primary, secondary, success, danger, warning, info, light, dark, link - default: primary
 +++

--- a/exampleSite/content/index/hero/index.md
+++ b/exampleSite/content/index/hero/index.md
@@ -17,16 +17,16 @@ header = "header.jpg"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "info" # primary, secondary, success, danger, warning, info, light, dark, link - default: primary
 
 [[buttons]]
   text = "Download"
-  link = "https://github.com/okkur/syna/releases"
+  url = "https://github.com/okkur/syna/releases"
   color = "primary"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "success"
 +++

--- a/exampleSite/content/index/item_button-center.md
+++ b/exampleSite/content/index/item_button-center.md
@@ -16,12 +16,12 @@ subtitle= "Easily center align the item fragment even with some buttons"
 
 [[buttons]]
   text = "Long Button"
-  link = "#"
+  url = "#"
   color = "primary"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "secondary"
 +++
 

--- a/exampleSite/content/index/item_button-left.md
+++ b/exampleSite/content/index/item_button-left.md
@@ -15,7 +15,7 @@ title = "Item Fragment Button Left"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "success"
 +++
 

--- a/exampleSite/content/index/item_button-right.md
+++ b/exampleSite/content/index/item_button-right.md
@@ -15,12 +15,12 @@ post = "With a simple subtitle"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "primary"
 
 [[buttons]]
   text = "Long Button"
-  link = "#"
+  url = "#"
   color = "secondary"
 +++
 

--- a/exampleSite/content/index/item_image-button-left.md
+++ b/exampleSite/content/index/item_image-button-left.md
@@ -17,12 +17,12 @@ image = "screenshot.png"
 
 [[buttons]]
   text = "Button"
-  link = "#"
+  url = "#"
   color = "primary"
 
 [[buttons]]
   text = "Long Button"
-  link = "#"
+  url = "#"
   color = "secondary"
 +++
 

--- a/exampleSite/content/index/item_image-table-left.md
+++ b/exampleSite/content/index/item_image-table-left.md
@@ -50,13 +50,13 @@ image = "screenshot.png"
 
   [[rows.values]]
     button = "Button"
-    link = "#"
+    url = "#"
     color = "success"
     center = true
 
   [[rows.values]]
     button = "Long Button"
-    link = "#"
+    url = "#"
     color = "danger"
 
 [[rows]]
@@ -77,6 +77,6 @@ image = "screenshot.png"
 
   [[rows.values]]
     icon = "fa-download"
-    link = "#"
+    url = "#"
     center = true
 +++

--- a/exampleSite/content/index/items/column1.md
+++ b/exampleSite/content/index/items/column1.md
@@ -2,7 +2,7 @@
 title = "Column 1"
 weight = 10
 icon = "fas fa-random"
-link = "#"
+url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/items/column2.md
+++ b/exampleSite/content/index/items/column2.md
@@ -2,7 +2,7 @@
 title = "Column 2"
 weight = 20
 icon = "fas fa-code"
-#link = "#"
+#url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/items/column3.md
+++ b/exampleSite/content/index/items/column3.md
@@ -2,7 +2,7 @@
 title = "Column 3"
 weight = 30
 icon = "fas fa-code"
-#link = "#"
+#url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/items_only/column-1.md
+++ b/exampleSite/content/index/items_only/column-1.md
@@ -2,7 +2,7 @@
 title = "Column 1"
 weight = 10
 icon = "fas fa-random"
-#link = "#"
+#url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/items_only/column-2.md
+++ b/exampleSite/content/index/items_only/column-2.md
@@ -2,7 +2,7 @@
 title = "Column 2"
 weight = 20
 icon = "fas fa-random"
-#link = "#"
+#url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/items_only/column-3.md
+++ b/exampleSite/content/index/items_only/column-3.md
@@ -2,7 +2,7 @@
 title = "Column 3"
 weight = 30
 icon = "fas fa-code"
-#link = "#"
+#url = "#"
 +++
 
 Showcasing descriptions for column based items

--- a/exampleSite/content/index/logos.md
+++ b/exampleSite/content/index/logos.md
@@ -12,17 +12,17 @@ subtitle = "Even linking is possible"
   name = "hugo"
   weight = 20
   image = "hugo.svg"
-  link = "#"
+  url = "#"
 
 [[logos]]
   name = "go"
   weight = 10
   image = "go.svg"
-  link = "#"
+  url = "#"
 
 [[logos]]
   name = "caddy"
   weight = 30
   image = "caddy.svg"
-  link = "#"
+  url = "#"
 +++

--- a/exampleSite/content/index/logos_only.md
+++ b/exampleSite/content/index/logos_only.md
@@ -12,5 +12,5 @@ background = "dark"
   name = "syna"
   weight = 10
   image = "syna.svg"
-  #link = "#"
+  #url = "#"
 +++

--- a/exampleSite/content/index/portfolio/bio.md
+++ b/exampleSite/content/index/portfolio/bio.md
@@ -15,7 +15,7 @@
 
   [[icons]]
     icon = "fab fa-linkedin-in"
-    link = "#"
+    url = "#"
 +++
 
 Hugely huge Gopher

--- a/exampleSite/content/index/table.md
+++ b/exampleSite/content/index/table.md
@@ -45,12 +45,12 @@ subtitle= "Tables are responsive by default"
 
   [[rows.values]]
     button = "Long Button"
-    link = "#"
+    url = "#"
     color = "success"
 
   [[rows.values]]
     button = "Button"
-    link = "#"
+    url = "#"
     color = "danger"
     center = true
 
@@ -72,6 +72,6 @@ subtitle= "Tables are responsive by default"
 
   [[rows.values]]
     icon = "fas fa-download"
-    link = "#"
+    url = "#"
     center = true
 +++

--- a/layouts/partials/fragments/buttons.html
+++ b/layouts/partials/fragments/buttons.html
@@ -38,10 +38,10 @@
       {{- end }}
       <div class="row text-center justify-content-center">
         {{- range .Params.buttons }}
-          <a class="btn btn-lg m-2{{ if hasPrefix .link "#" }} anchor{{ end }}
+          <a class="btn btn-lg m-2{{ if hasPrefix .url "#" }} anchor{{ end }}
             {{- $color := .color | default "primary" -}}
             {{- printf " btn-%s" $color -}}
-          " href="{{ .link | relLangURL }}">
+          " href="{{ .url | relLangURL }}">
             {{- .text -}}
           </a>
         {{- end }}

--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -42,7 +42,7 @@
             {{- .title -}}
           </h4>
           {{- if .image }}
-          <a href="{{ .link }}">
+          <a href="{{ .url }}">
             <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid w-50" alt="{{ .text }}">
           </a>
           {{- else }}

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -112,10 +112,10 @@
     {{- end -}}
   {{- end -}}
   {{- range .Params.buttons }}
-    <a class="overlay btn btn-lg m-2{{ if hasPrefix .link " # " }} anchor{{ end }}
+    <a class="overlay btn btn-lg m-2{{ if hasPrefix .url " # " }} anchor{{ end }}
           {{- $color := .color | default "primary" -}}
           {{- printf " btn-%s " $color -}}
-        " href="{{ .link | relLangURL }}">
+        " href="{{ .url | relLangURL }}">
     <div class="column justify-content-center align-content-center">
       {{- .text -}}
     </div>

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -125,10 +125,10 @@
                 {{- if and (not .Params.icon) (not .Params.image) -}}
                   {{- range .Params.buttons }}
                     <a class="btn btn-lg m-2 d-none d-lg-inline
-                      {{ if hasPrefix .link "#" }} anchor{{ end }}
+                      {{ if hasPrefix .url "#" }} anchor{{ end }}
                       {{- $color := .color | default "primary" -}}
                       {{- printf " btn-%s" $color -}}
-                    " href="{{ .link | relLangURL }}">
+                    " href="{{ .url | relLangURL }}">
                       {{- .text -}}
                     </a>
                   {{- end -}}
@@ -178,10 +178,10 @@
             <div class="col-12 text-center text-lg-left">
               {{- range .Params.buttons }}
                 <a class="btn btn-lg m-2
-                  {{ if hasPrefix .link "#" }} anchor{{ end }}
+                  {{ if hasPrefix .url "#" }} anchor{{ end }}
                   {{- $color := .color | default "primary" -}}
                   {{- printf " btn-%s" $color -}}
-                " href="{{ .link | relLangURL }}">
+                " href="{{ .url | relLangURL }}">
                   {{- .text -}}
                 </a>
               {{- end }}
@@ -230,10 +230,10 @@
                               {{- end -}}
                             ">
                               <a class="btn
-                              {{ if hasPrefix .link "#" }} anchor{{ end }}
+                              {{ if hasPrefix .url "#" }} anchor{{ end }}
                               {{- $color := .color | default "primary" -}}
                               {{- printf " btn-%s" $color -}}
-                            " href="{{ .link | relLangURL }}">
+                            " href="{{ .url | relLangURL }}">
                               {{- .button -}}
                             </a>
                           </td>
@@ -243,7 +243,7 @@
                               {{- printf " text-center" -}}
                             {{- end -}}
                           ">
-                            <a href="{{ .links }}">
+                            <a href="{{ .urls }}">
                               <i class="{{ .icon }} fa-2x"></i>
                             </a>
                           </td>
@@ -311,10 +311,10 @@
               <div class="col-12 text-center">
                 {{- range .Params.buttons }}
                   <a class="btn btn-lg m-2
-                    {{ if hasPrefix .link "#" }} anchor{{ end }}
+                    {{ if hasPrefix .url "#" }} anchor{{ end }}
                     {{- $color := .color | default "primary" -}}
                     {{- printf " btn-%s" $color -}}
-                  " href="{{ .link | relLangURL }}">
+                  " href="{{ .url | relLangURL }}">
                     {{- .text -}}
                   </a>
                   {{- end }}

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -60,8 +60,8 @@
                   {{- printf " text-%s" "light" -}}
                 {{- end -}}
               ">
-                {{- if $item.link }}
-                  <a href="{{ $item.link | relLangURL }}" class="
+                {{- if $item.url }}
+                  <a href="{{ $item.url | relLangURL }}" class="
                     {{- if eq $bg "primary" -}}
                       {{- printf " text-%s" "dark" -}}
                     {{- end -}}

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -63,8 +63,8 @@
           {{/* End of do not change */}}
 
           <div class="col-7 col-sm-4 text-center py-2">
-            {{- if .link }}
-              <a href="{{ .link }}">
+            {{- if .url }}
+              <a href="{{ .url }}">
                 <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .name }}">
               </a>
             {{- else }}

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -121,7 +121,7 @@
                   <div class="row justify-content-center pt-4">
                     {{- range $member.icons -}}
                       <span class="fa-stack fa-2x m-2">
-                        <a href="{{ .link }}">
+                        <a href="{{ .url }}">
                           <i class="fas fa-circle fa-stack-2x
                             {{- if eq $bg "primary" -}}
                               {{- printf " text-%s" "dark" -}}
@@ -234,7 +234,7 @@
                     <div class="row justify-content-center pt-4">
                       {{- range $member.icons -}}
                         <span class="fa-stack fa-2x m-2">
-                          <a href="{{ .link }}">
+                          <a href="{{ .url }}">
                             <i class="fas fa-circle fa-stack-2x
                               {{- if eq $bg "primary" -}}
                                 {{- printf " text-%s" "dark" -}}

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -83,10 +83,10 @@
                               {{- end -}}
                             ">
                               <a class="btn
-                              {{ if hasPrefix .link "#" }} anchor{{ end }}
+                              {{ if hasPrefix .url "#" }} anchor{{ end }}
                               {{- $color := .color | default "primary" -}}
                               {{- printf " btn-%s" $color -}}
-                            " href="{{ .link | relLangURL }}">
+                            " href="{{ .url | relLangURL }}">
                               {{- .button -}}
                             </a>
                           </td>


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename all variables named link to url so it's consistent with Hugo

**Which issue this PR fixes**:
fixes #182 

**Release note**:
```release-note
BREAKING: Renamed `link` to `url` across all fragments
```
