### PR TITLE
Remove color switch for the title on member fragment in single mode

### DIFF
--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -196,13 +196,7 @@
                       {{- printf " text-muted text-%s" "secondary" -}}
                     {{- end -}}
                   ">
-                    <div class="mb-3
-                      {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-                        {{- printf " text-%s" "dark" -}}
-                      {{- else -}}
-                        {{- printf " text-%s" "light" -}}
-                      {{- end -}}
-                    ">
+                    <div class="mb-3 text-dark">
                       <h1>
                         {{- $member.title -}}
                       </h1>


### PR DESCRIPTION
**What this PR does / why we need it**:
Member fragment had an extra color switch for part of it's text that was not needed since member fragment in single mode has a card which doesn't change color with background so the text was unreadable with some background colors.

**Which issue this PR fixes**:
fixes #215 

**Release note**:
```release-note
Fix member fragment single member mode's text color in dark backgrounds
```
