### PR TITLE
Add blog support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,6 +53,11 @@ googleAnalytics = ""
   weight = 10
 
 [[menu.main]]
+  url = "/blog"
+  name = "Blog"
+  weight = 15
+
+[[menu.main]]
   url = "/article"
   name = "Article"
   weight = 20

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,7 +53,7 @@ googleAnalytics = ""
   weight = 10
 
 [[menu.main]]
-  url = "/blog"
+  url = "/blog/archives"
   name = "Blog"
   weight = 15
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,7 +53,7 @@ googleAnalytics = ""
   weight = 10
 
 [[menu.main]]
-  url = "/blog/archives"
+  url = "/blog"
   name = "Blog"
   weight = 15
 

--- a/exampleSite/content/blog/_index/index.md
+++ b/exampleSite/content/blog/_index/index.md
@@ -2,6 +2,7 @@
 date = "2018-07-06"
 fragment = "list"
 weight = 100
+url = "/blog"
 
 #count = 10 # Default value is 10
 #section = "" # Default value is current section

--- a/exampleSite/content/blog/_index/index.md
+++ b/exampleSite/content/blog/_index/index.md
@@ -1,0 +1,6 @@
++++
+date = "2018-07-06"
+url = "/blog"
+fragment = "list"
+weight = 100
++++

--- a/exampleSite/content/blog/archives/index.md
+++ b/exampleSite/content/blog/archives/index.md
@@ -1,6 +1,5 @@
 +++
 date = "2018-07-06"
-url = "/blog"
 fragment = "list"
 weight = 100
 +++

--- a/exampleSite/content/blog/archives/index.md
+++ b/exampleSite/content/blog/archives/index.md
@@ -2,4 +2,7 @@
 date = "2018-07-06"
 fragment = "list"
 weight = 100
+
+#count = 10 # Default value is 10
+#section = "" # Default value is current section
 +++

--- a/exampleSite/content/blog/article-1/index.md
+++ b/exampleSite/content/blog/article-1/index.md
@@ -1,0 +1,29 @@
++++
+date = "2018-07-06"
+fragment = "content-single"
+weight = 100
+#background = ""
+
+title = "First sample blog"
+#subtitle = ""
++++
+
+I have a 10 year old son. He has words. He is so good with these words it's unbelievable. I write the best placeholder text, and I'm the biggest developer on the web by far... While that's mock-ups and this is politics, are they really so different? He’s not a word hero. He’s a word hero because he was captured. I like text that wasn’t captured. Lorem Ipsum is unattractive, both inside and out. I fully understand why it’s former users left it for something else. They made a good decision.
+
+You know, it really doesn’t matter what you write as long as you’ve got a young, and beautiful, piece of text. I will write some great placeholder text – and nobody writes better placeholder text than me, believe me – and I’ll write it very inexpensively. I will write some great, great text on your website’s Southern border, and I will make Google pay for that text. Mark my words. Trump Ipsum is calling for a total and complete shutdown of Muslim text entering your website. Despite the constant negative ipsum covfefe.
+
+All of the words in Lorem Ipsum have flirted with me - consciously or unconsciously. That's to be expected.
+
+Lorem Ipsum is the single greatest threat. We are not - we are not keeping up with other websites.
+
+The other thing with Lorem Ipsum is that you have to take out its family.
+
+That other text? Sadly, it’s no longer a 10. We are going to make placeholder text great again. Greater than ever before.
+
+You’re disgusting.
+
+Lorem Ipsum is unattractive, both inside and out. I fully understand why it’s former users left it for something else. They made a good decision. You could see there was text coming out of her eyes, text coming out of her wherever.
+
+I think my strongest asset maybe by far is my temperament. I have a placeholding temperament.
+
+Look at that text! Would anyone use that? Can you imagine that, the text of your next webpage?! I will write some great placeholder text – and nobody writes better placeholder text than me, believe me – and I’ll write it very inexpensively. I will write some great, great text on your website’s Southern border, and I will make Google pay for that text. Mark my words. I was going to say something extremely rough to Lorem Ipsum, to its family, and I said to myself, "I can't do it. I just can't do it. It's inappropriate. It's not nice."

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,6 +4,10 @@
 - id: en
   translation: "English"
 
+# Content
+- id: content.readmore
+  translation: "Read more..."
+
 # Contact Form
 - id: contact.defaultNameError
   translation: "Please enter your name"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
   {{- end -}}
   {{- $local_fragments := .Resources.ByType "page" -}}
 
-  {{- $.Scratch.Set "fragments" slice -}}
+  {{- $.Scratch.Set "fragments" (slice .) -}}
   {{- range $local_fragments -}}
     {{- $.Scratch.Add "fragments" (slice .) -}}
   {{- end -}}
@@ -29,6 +29,7 @@
     {{- end -}}
   {{- end -}}
 
+  {{- $page := . }}
   {{- range sort ($.Scratch.Get "fragments" | default slice) "Params.weight" -}}
     {{- if and (not .Params.disabled) (isset .Params "fragment") -}}
       {{/* Cleanup .Name to be more useful within fragments */}}
@@ -39,7 +40,7 @@
       {{- $page_path := replace $file_path (printf "/%s" $name) "" -}}
       {{- $fallthrough := (dict "file_path" $file_path "page_path" $page_path ) -}}
 
-      {{- partial (print "fragments/" .Params.fragment ".html") (dict "root" $ "Site" $.Site "resources" $.Resources "self" . "Params" .Params "Name" $name "fallthrough" $fallthrough) -}}
+      {{- partial (print "fragments/" .Params.fragment ".html") (dict "root" $ "Site" $.Site "page" $page "resources" $.Resources "self" . "Params" .Params "Name" $name "fallthrough" $fallthrough) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -3,7 +3,7 @@
   where functions achieving this. First where gets all the pages in blog
   section, the second one removes current page from the mix and the last one
   removes the section (.Site.Pages returns the current section as a page). */}}
-{{- $articles := where (where .Site.Pages "Section" (.Params.section | default .page.Section)) "Params.fragment" "in" (slice "content-single" "content-split") -}}
+{{- $pages := where (where .Site.Pages "Section" (.Params.section | default .page.Section)) "Params.fragment" "in" (slice "content-single" "content-split") -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Blog -->" | safeHTML }}
@@ -18,7 +18,7 @@
             {{- printf " text-muted text-%s" "secondary" -}}
           {{- end -}}
         ">
-          {{- range first (.Params.article_count | default 10) $articles }}
+          {{- range first (.Params.count | default 10) $pages }}
             <article class="col-12 mb-4">
               {{- if .Params.title }}
                 <div class="col-12 pl-0

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -1,0 +1,108 @@
+{{/*
+  This variable stores all the page bundles in the blog section. There are three
+  where functions achieving this. First where gets all the pages in blog
+  section, the second one removes current page from the mix and the last one
+  removes the section (.Site.Pages returns the current section as a page). */}}
+{{- $articles := where (where .Site.Pages "Section" (.Params.section | default .page.Section)) "Params.fragment" "in" (slice "content-single" "content-split") -}}
+{{- $bg := .Params.background | default "light" }}
+
+{{ "<!-- Blog -->" | safeHTML }}
+<section id="{{ .Name }}">
+  <div class="overlay container-fluid {{- printf " bg-%s" $bg -}}">
+    <div class="container py-5">
+      <l class="row">
+        <div class="col-12
+          {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+            {{- printf " text-%s" "dark" -}}
+          {{- else -}}
+            {{- printf " text-muted text-%s" "secondary" -}}
+          {{- end -}}
+        ">
+          {{- range first (.Params.article_count | default 10) $articles }}
+            <article class="col-12 mb-4">
+              {{- if .Params.title }}
+                <div class="col-12 pl-0
+                  {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
+                    {{- printf " text-%s" "dark" -}}
+                  {{- else -}}
+                    {{- printf " text-%s" "light" -}}
+                  {{- end -}}
+                ">
+                  <a href="{{ .URL }}">
+                    <h3>
+                      {{- .Params.title | markdownify -}}
+                    </h3>
+                  </a>
+                </div>
+              {{- end -}}
+              {{- if .Params.image -}}
+                {{/* Global resource fallback - can also be used within loops */}}
+                {{- $image := .Params.image -}}
+
+                {{- $name := strings.TrimSuffix ".md" (replace .Name "/index.md" "") -}}
+                {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
+                {{- $page_path := replace $file_path (printf "/%s" $name) "" -}}
+                {{- $fallthrough := (dict "file_path" $file_path "page_path" $page_path ) -}}
+
+                {{/* Do not change the following snippet */}}
+                {{/* Code is duplicated throughout the code */}}
+                {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+
+                {{/* Page specific resource */}}
+                {{- $location := (printf "%s/%s" $fallthrough.page_path $image) -}}
+                {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                {{- end -}}
+            
+                {{/* Fragment specific resource */}}
+                {{- $location := (printf "%s/%s" $fallthrough.file_path $image) -}}
+                {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                {{- end -}}
+                {{/* End of do not change */}}
+                <a href="{{ .URL }}">
+                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ .Params.subtitle | default .Params.title }}" class="img-fluid mb-4">
+                </a>
+              {{- end -}}
+              <div class="col-12 pl-0
+                {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+                  {{- printf " text-%s" "dark" -}}
+                {{- else -}}
+                  {{- printf " text-muted text-%s" "secondary" -}}
+                {{- end -}}
+              ">
+                {{- if and (isset .Params "fragment") (in (slice "content-split" "content-single") .Params.fragment) }}
+                  {{ .Summary }}
+                  {{- if .Truncated -}}
+                    <a class="ml-2 badge
+                    {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+                      {{- printf " badge-%s" "dark" -}}
+                    {{- else -}}
+                      {{- printf " badge-%s" "secondary" -}}
+                    {{- end -}}" href="{{ .URL }}">{{ i18n "content.readmore" | default "Read more..." }}</a>
+                  {{- end }}
+                {{- else }}
+                  {{- range first 1 (where (.Resources.ByType "page") "Params.fragment" "in" (slice "content-split" "content-single")) }}
+                    {{ .Summary }}
+                    {{- if .Truncated -}}
+                      <a class="ml-2 badge
+                      {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+                        {{- printf " badge-%s" "dark" -}}
+                      {{- else -}}
+                        {{- printf " badge-%s" "secondary" -}}
+                      {{- end -}}" href="{{ .URL }}">{{ i18n "content.readmore" }}</a>
+                    {{- end }}
+                  {{- end -}}
+                {{- end -}}
+              </div>
+            </article>
+          {{- end -}}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/static/contact.js
+++ b/static/contact.js
@@ -36,17 +36,32 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules

--- a/static/hero.js
+++ b/static/hero.js
@@ -36,17 +36,32 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules

--- a/static/main.js
+++ b/static/main.js
@@ -36,17 +36,32 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules


### PR DESCRIPTION
**What this PR does / why we need it**:
Add simple blog support. This PR adds support for index files to be fragments themselves to make smaller pages easier to create. Also adds list fragment that is able to list pages from different sections and is used in the exampleSite to list latest articles.

**Which issue this PR fixes**:
fixes #4 

**Release note**:
```release-note
- Add new list fragment that lists pages from a single section
- Index files now can be fragments
```
