### PR TITLE
Bump minimum Hugo version required by Syna

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -4,7 +4,7 @@ licenselink = "https://github.com/okkur/syna/blob/master/LICENSE"
 description = "A customizable one to multi page theme for open source projects, companies and freelancers."
 homepage = "https://github.com/okkur/syna"
 tags = ["open source", "company", "one-page", "multi-page"]
-min_version = 0.29
+min_version = 0.40
 
 [author]
   name = "okkur"


### PR DESCRIPTION
**What this PR does / why we need it**:
Minimum required version has changed to v0.40

**Release note**:
```release-note
Minimum required version of Hugo has changed to v0.40
```
