### PR TITLE
Add latest theme git commit hash to website head

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,6 +17,7 @@ googleAnalytics = ""
 [params]
   name = "Okkur Labs"
   description = "Open Source Theme for your next project"
+  display_theme_commit = true
 
   [params.style]
     #background = "secondary"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,7 @@
   <meta name="theme" content="Syna Theme - (https://github.com/okkur/syna)">
   <meta name="theme description" content="Highly modular open source theme for Hugo built with Bootstrap 4">
   <meta name="theme author" content="Okkur Labs - https://okkur.io">
+  <meta name="theme commit" content="{{ .GitInfo.AbbreviatedHash }}">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="Content-Language" content="{{ .Site.LanguageCode | default "en-us" }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,9 @@
   <meta name="theme" content="Syna Theme - (https://github.com/okkur/syna)">
   <meta name="theme description" content="Highly modular open source theme for Hugo built with Bootstrap 4">
   <meta name="theme author" content="Okkur Labs - https://okkur.io">
+  {{- if .Site.Params.display_theme_commit }}
   <meta name="theme commit" content="{{ .GitInfo.AbbreviatedHash }}">
+  {{- end }}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="Content-Language" content="{{ .Site.LanguageCode | default "en-us" }}">


### PR DESCRIPTION
**What this PR does / why we need it**:
Add latest theme commit to the head of websites using Syna. The data can be removed by setting `display_theme_commit` to false in the config file.

**Which issue this PR fixes**:
fixes #200 

**Release note**:
```release-note
Websites using Syna now show the commit of the theme that they're using (can be turned off by display_theme_commit)
```
