### PR TITLE
Remove the icon container when there is no icon in items fragment

### DIFF
--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -48,16 +48,18 @@
             {{- if not (in .Name "/index.md") -}}
               {{- $item := .Params }}
               <div class="col-md-4 text-center">
-                <span class="fa-stack fa-3x m-2">
-                  <i class="fas fa-circle fa-stack-2x
-                    {{- if eq $bg "primary" -}}
-                      {{- printf " text-%s" "dark" -}}
-                    {{- else -}}
-                      {{- printf " text-%s" "primary" -}}
-                    {{- end -}}
-                  "></i>
-                  <i class="{{ $item.icon }} fa-stack-1x fa-inverse"></i>
-                </span>
+                {{- if $item.icon }}
+                  <span class="fa-stack fa-3x m-2">
+                    <i class="fas fa-circle fa-stack-2x
+                      {{- if eq $bg "primary" -}}
+                        {{- printf " text-%s" "dark" -}}
+                      {{- else -}}
+                        {{- printf " text-%s" "primary" -}}
+                      {{- end -}}
+                    "></i>
+                    <i class="{{ $item.icon }} fa-stack-1x fa-inverse"></i>
+                  </span>
+                {{- end }}
                 <h4 class="mb-3
                   {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                     {{- printf " text-%s" "dark" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
The items fragment displayed items with icons. If there were no icons, the circle around it would still show. With this PR that is fixed.

![image](https://user-images.githubusercontent.com/14017717/42693110-48f34054-86c3-11e8-909e-affb793305c3.png)

**Which issue this PR fixes**:
fixes #197 

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix: Remove icon circle when there were no icons set in items fragment.
```
