### PR TITLE
Make content sidebar alignment configurable

### DIFF
--- a/exampleSite/content/about-split/content.md
+++ b/exampleSite/content/about-split/content.md
@@ -10,7 +10,7 @@ subtitle = "Split in two!"
 
 [sidebar]
   title = "Sidebar"
-  #right = true
+  align = "left"
   content = """
 So much information  
 Phone numbers  

--- a/exampleSite/content/about-split/content.md
+++ b/exampleSite/content/about-split/content.md
@@ -10,6 +10,7 @@ subtitle = "Split in two!"
 
 [sidebar]
   title = "Sidebar"
+  #right = true
   content = """
 So much information  
 Phone numbers  

--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -9,7 +9,7 @@
     <div class="container py-5">
       <div class="row">
         {{- with .Params.sidebar -}}
-          <div class="col-md-3 pb-4 {{- if .right }} order-1 {{- end -}}">
+          <div class="col-md-3 pb-4 {{- if (eq .align "right") }} order-1 {{- else }} order-0 {{- end -}}">
             {{- if .title }}
               <div class="col-12 pb-3
                 {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}

--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -9,7 +9,7 @@
     <div class="container py-5">
       <div class="row">
         {{- with .Params.sidebar -}}
-          <div class="col-md-3 pb-4">
+          <div class="col-md-3 pb-4 {{- if .right }} order-1 {{- end -}}">
             {{- if .title }}
               <div class="col-12 pb-3
                 {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Content fragment's sidebar can now be aligned on the right side of the page.

**Which issue this PR fixes**:
fixes #236 

**Release note**:
```release-note
`content` fragment: Sidebar can be displayed on the right side.
```
