### PR TITLE
Make table cell alignment more flexible and fix issues within it

### DIFF
--- a/exampleSite/content/_index/table.md
+++ b/exampleSite/content/_index/table.md
@@ -52,7 +52,7 @@ subtitle= "Tables are responsive by default"
     button = "Button"
     url = "#"
     color = "danger"
-    center = true
+    align = "center"
 
 [[rows]]
   [[rows.values]]
@@ -73,5 +73,5 @@ subtitle= "Tables are responsive by default"
   [[rows.values]]
     icon = "fas fa-download"
     url = "#"
-    center = true
+    align = "center"
 +++

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -1,5 +1,4 @@
 {{- $bg := .Params.background | default "light" -}}
-{{- $align := .Params.align | default "center" }}
 
 {{ "<!-- Table -->" | safeHTML }}
 <section id="{{ .Name }}">
@@ -52,8 +51,8 @@
                       {{- $.Scratch.Set "col" 0 -}}
                       {{- range .Params.header.values }}
                         <th class="
-                          {{- if .center -}}
-                            {{- printf " text-center" -}}
+                          {{- if (in (slice "left" "center" "right") .align) -}}
+                            {{- printf " text-%s" .align -}}
                           {{- end -}}
                           {{- if .hide_on_mobile -}}
                             {{- print " hide-on-mobile" }}
@@ -78,12 +77,15 @@
                           ">{{ .header | markdownify }}</th>
                           {{- else if .button }}
                             <td class="align-middle
+                              {{- if (in (slice "left" "center" "right") .align) -}}
+                                {{- printf " text-%s" .align -}}
+                              {{- end -}}
                               {{- if (index $.Params.header.values $i).hide_on_mobile -}}
                                 {{- print " hide-on-mobile" }}
                               {{- end -}}
                             ">
                               <a class="btn
-                              {{ if hasPrefix .url "#" }} anchor{{ end }}
+                              {{- if hasPrefix .url "#" }} anchor{{- end -}}
                               {{- $color := .color | default "primary" -}}
                               {{- printf " btn-%s" $color -}}
                             " href="{{ .url | relLangURL }}">
@@ -92,8 +94,8 @@
                           </td>
                         {{- else if .icon }}
                           <td class="align-middle
-                            {{- if .center -}}
-                              {{- printf " text-center" -}}
+                            {{- if (in (slice "left" "center" "right") .align) -}}
+                              {{- printf " text-%s" .align -}}
                             {{- end -}}
                             {{- if (index $.Params.header.values $i).hide_on_mobile -}}
                               {{- print " hide-on-mobile" }}
@@ -105,8 +107,8 @@
                           </td>
                         {{- else }}
                           <td class="align-middle
-                            {{- if .center -}}
-                              {{- printf " text-center" -}}
+                            {{- if (in (slice "left" "center" "right") .align) -}}
+                              {{- printf " text-%s" .align -}}
                             {{- end -}}
                             {{- if (index $.Params.header.values $i).hide_on_mobile -}}
                               {{- print " hide-on-mobile" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Table cells were not alignable. They were only capable of being centered and that did not work on header rows and button containing cells. This PR fixes these issues.

**Which issue this PR fixes**:
fixes #207 

**Release note**:
```release-note
`table` fragment: You can now align table cells using `align` variable.
```
