### PR TITLE
Migrate 404 page from  global to _global

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,16 +1,16 @@
 <html lang="{{ .Site.LanguageCode | default (printf "en-us") }}">
 
-  {{ partial "head.html" . }}
+  {{- partial "head.html" . -}}
 
   <body class="bg-white">
-    {{ $global := .Site.GetPage "page" "global" }}
-    {{ if $global }}
-      {{ range ($global.Resources.ByType "page") }}
-        {{ if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") }}
-          {{ partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
+    {{- $global := .Site.GetPage "page" "_global" -}}
+    {{- if $global -}}
+      {{- range ($global.Resources.ByType "page") -}}
+        {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") -}}
+          {{- partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
 
     <section>
           <div class="jumbotron text-center mb-0">
@@ -30,7 +30,7 @@
           </div>
     </section>
 
-    {{ partial "js.html" . }}
+    {{- partial "js.html" . -}}
 
   </body>
 </html>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
It migrates the current global directory to _global in 404 page.

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #228 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Migrate 404 page from  global to _global
```
