### PR TITLE
Fix naming consistency for logo fragment

### DIFF
--- a/exampleSite/content/_index/logos.md
+++ b/exampleSite/content/_index/logos.md
@@ -9,19 +9,19 @@ title = "Logo Fragment"
 subtitle = "Even linking is possible"
 
 [[logos]]
-  name = "hugo"
+  text = "hugo"
   weight = 20
   image = "hugo.svg"
   url = "#"
 
 [[logos]]
-  name = "go"
+  text = "go"
   weight = 10
   image = "go.svg"
   url = "#"
 
 [[logos]]
-  name = "caddy"
+  text = "caddy"
   weight = 30
   image = "caddy.svg"
   url = "#"

--- a/exampleSite/content/_index/logos_only.md
+++ b/exampleSite/content/_index/logos_only.md
@@ -9,7 +9,7 @@ background = "dark"
 #subtitle = ""
 
 [[logos]]
-  name = "syna"
+  text = "syna"
   weight = 10
   image = "syna.svg"
   #url = "#"

--- a/exampleSite/content/dev/fallthrough/global/logos.md
+++ b/exampleSite/content/dev/fallthrough/global/logos.md
@@ -8,7 +8,7 @@ background = "dark"
 title = "logos"
 
 [[logos]]
-  name = "syna"
+  text = "syna"
   weight = 10
   image = "resource_logo.svg"
   #url = "#"

--- a/exampleSite/content/dev/fallthrough/page/logos.md
+++ b/exampleSite/content/dev/fallthrough/page/logos.md
@@ -8,7 +8,7 @@ background = "dark"
 title = "logos"
 
 [[logos]]
-  name = "syna"
+  text = "syna"
   weight = 10
   image = "resource_logo.svg"
   #url = "#"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,36 +1,36 @@
 <html lang="{{ .Site.LanguageCode | default (printf "en-us") }}">
 
-  {{- partial "head.html" . -}}
+  {{ partial "head.html" . }}
 
   <body class="bg-white">
-    {{- $global := .Site.GetPage "page" "_global" -}}
-    {{- if $global -}}
-      {{- range ($global.Resources.ByType "page") -}}
-        {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") -}}
-          {{- partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
+    {{ $global := .Site.GetPage "page" "global" }}
+    {{ if $global }}
+      {{ range ($global.Resources.ByType "page") }}
+        {{ if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") }}
+          {{ partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
 
     <section>
           <div class="jumbotron text-center mb-0">
             <img class="img-fluid" src="{{ printf "images/logo.svg" | relURL }}"></img>
             <h1 class="jumbotron-heading my-5">
-              {{- i18n "404.title" -}}
+              {{ i18n "404.title" }}
             </h1>
             <h3 class="my-4">
-              {{- i18n "404.subtitle" -}}
+              {{ i18n "404.subtitle" }}
             </h3>
             <h5 class="my-4">
-              {{- i18n "404.direction" -}}
+              {{ i18n "404.direction" }}
             </h5>
             <a class="btn btn-primary btn-lg my-4" href="/">
-              {{- i18n "404.button" -}}
+              {{ i18n "404.button" }}
             </a>
           </div>
     </section>
 
-    {{- partial "js.html" . -}}
+    {{ partial "js.html" . }}
 
   </body>
 </html>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,16 +1,16 @@
 <html lang="{{ .Site.LanguageCode | default (printf "en-us") }}">
 
-  {{ partial "head.html" . }}
+  {{- partial "head.html" . -}}
 
   <body class="bg-white">
-    {{ $global := .Site.GetPage "page" "global" }}
-    {{ if $global }}
-      {{ range ($global.Resources.ByType "page") }}
-        {{ if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") }}
-          {{ partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
+    {{- $global := .Site.GetPage "page" "_global" -}}
+    {{- if $global -}}
+      {{- range ($global.Resources.ByType "page") -}}
+        {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") -}}
+          {{- partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
 
     <section>
           <div class="jumbotron text-center mb-0">
@@ -30,7 +30,7 @@
           </div>
     </section>
 
-    {{ partial "js.html" . }}
+    {{- partial "js.html" . -}}
 
   </body>
 </html>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,36 +1,36 @@
 <html lang="{{ .Site.LanguageCode | default (printf "en-us") }}">
 
-  {{ partial "head.html" . }}
+  {{- partial "head.html" . -}}
 
   <body class="bg-white">
-    {{ $global := .Site.GetPage "page" "global" }}
-    {{ if $global }}
-      {{ range ($global.Resources.ByType "page") }}
-        {{ if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") }}
-          {{ partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
+    {{- $global := .Site.GetPage "page" "_global" -}}
+    {{- if $global -}}
+      {{- range ($global.Resources.ByType "page") -}}
+        {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") -}}
+          {{- partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
 
     <section>
           <div class="jumbotron text-center mb-0">
             <img class="img-fluid" src="{{ printf "images/logo.svg" | relURL }}"></img>
             <h1 class="jumbotron-heading my-5">
-              {{ i18n "404.title" }}
+              {{- i18n "404.title" -}}
             </h1>
             <h3 class="my-4">
-              {{ i18n "404.subtitle" }}
+              {{- i18n "404.subtitle" -}}
             </h3>
             <h5 class="my-4">
-              {{ i18n "404.direction" }}
+              {{- i18n "404.direction" -}}
             </h5>
             <a class="btn btn-primary btn-lg my-4" href="/">
-              {{ i18n "404.button" }}
+              {{- i18n "404.button" -}}
             </a>
           </div>
     </section>
 
-    {{ partial "js.html" . }}
+    {{- partial "js.html" . -}}
 
   </body>
 </html>

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -65,10 +65,10 @@
           <div class="col-7 col-sm-4 text-center py-2">
             {{- if .url }}
               <a href="{{ .url }}">
-                <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .name }}">
+                <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
               </a>
             {{- else }}
-              <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .name }}">
+              <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
             {{- end }}
           </div>
         {{- end }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
It changes all "name" instance to "text" to enable consistent naming for all fragments.

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #213 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Fix naming consistency for logo fragment
```
