### PR TITLE
Fix button alignment in item fragment when there is an icon

### DIFF
--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -169,13 +169,13 @@
                   {{- printf " text-muted text-%s" "secondary" -}}
                 {{- end -}}
               ">
-                {{- .self.Content  | markdownify -}}
+                {{- .self.Content | markdownify -}}
               </div>
             </div>
           </div>
           {{- end -}}
           {{- if or .Params.icon .Params.image }}
-            <div class="col-12 text-center text-lg-left">
+            <div class="col-12 text-center mb-2 {{ printf "text-lg-%s" $align }}">
               {{- range .Params.buttons }}
                 <a class="btn btn-lg m-2
                   {{ if hasPrefix .url "#" }} anchor{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix button alignment in item fragment when there is an icon

![image](https://user-images.githubusercontent.com/14017717/42894912-6fe3e3b8-8acd-11e8-8a1b-edb4ab73e92b.png)

**Which issue this PR fixes**:
fixes #202 

**Special notes for your reviewer**:
Item fragment is too complicated. Let's consider simplifying it.

**Release note**:
```release-note
bug: Item fragment didn't align buttons when there was an icon present
```
