### PR TITLE
Fix table and item fragment icon urls

### DIFF
--- a/exampleSite/content/_index/item_image-table-left.md
+++ b/exampleSite/content/_index/item_image-table-left.md
@@ -76,7 +76,7 @@ image = "screenshot.png"
     text = ""
 
   [[rows.values]]
-    icon = "fa-download"
+    icon = "fas fa-download"
     url = "#"
     center = true
 +++

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -243,7 +243,7 @@
                               {{- printf " text-center" -}}
                             {{- end -}}
                           ">
-                            <a href="{{ .urls }}">
+                            <a href="{{ .url }}">
                               <i class="{{ .icon }} fa-2x"></i>
                             </a>
                           </td>

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -101,7 +101,7 @@
                               {{- print " hide-on-mobile" }}
                             {{- end -}}
                           ">
-                            <a href="{{ .links }}">
+                            <a href="{{ .url }}">
                               <i class="{{ .icon }} fa-2x"></i>
                             </a>
                           </td>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix table and item fragment icon urls

**Which issue this PR fixes**:
fixes #209, #210

**Special notes for your reviewer**:

**Release note**:
```release-note
bug: Item and table fragment icon urls were not working
```
