### PR TITLE
Fix 404 page logo alt text

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -13,21 +13,21 @@
     {{- end -}}
 
     <section>
-          <div class="jumbotron text-center mb-0">
-            <img class="img-fluid" src="{{ printf "images/logo.svg" | relURL }}"></img>
-            <h1 class="jumbotron-heading my-5">
-              {{- i18n "404.title" -}}
-            </h1>
-            <h3 class="my-4">
-              {{- i18n "404.subtitle" -}}
-            </h3>
-            <h5 class="my-4">
-              {{- i18n "404.direction" -}}
-            </h5>
-            <a class="btn btn-primary btn-lg my-4" href="/">
-              {{- i18n "404.button" -}}
-            </a>
-          </div>
+      <div class="jumbotron text-center mb-0">
+        <img class="img-fluid" src="{{ printf "images/logo.svg" | relURL }}" alt="{{ .Site.Title }}"></img>
+        <h1 class="jumbotron-heading my-5">
+          {{- i18n "404.title" -}}
+        </h1>
+        <h3 class="my-4">
+          {{- i18n "404.subtitle" -}}
+        </h3>
+        <h5 class="my-4">
+          {{- i18n "404.direction" -}}
+        </h5>
+        <a class="btn btn-primary btn-lg my-4" href="/">
+          {{- i18n "404.button" -}}
+        </a>
+      </div>
     </section>
 
     {{- partial "js.html" . -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Using alt text on the image seems like a good idea for this issue. It's more accessible as well.

![image](https://user-images.githubusercontent.com/14017717/42896937-ad26516a-8ad3-11e8-9c4e-642f95d49697.png)

**Which issue this PR fixes**:
fixes #248 
