### PR TITLE
Refactor 404 layout

### DIFF
--- a/exampleSite/content/_global/404.md
+++ b/exampleSite/content/_global/404.md
@@ -1,0 +1,11 @@
++++
+date = "2018-07-22"
+fragment = "404"
+weight = 150
+
+#title = "" # default i18n "404.title"
+#subtitle = "" # default i18n "404.subtitle"
+#redirect_text = "" # default i18n "404.direction"
+#button_text = "" # default i18n "404.button"
+#redirect_url = "" # default /
++++

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,32 +3,56 @@
   {{- partial "head.html" . -}}
 
   <body class="bg-white">
+    {{/*
+      This code may not be understandable immediately. This is trying to find all
+      the resources (read fragments) for each page and all the global fragments.
+      When combining global and local fragments, local ones have more priority.
+      So if there is only one footer fragment and that is global, that footer
+      fragment is shown. The same is true if there are no global footer fragments
+      and one local one. But if there is one global footer fragment and one local
+      footer fragment, the local one is rendered. Filename is checked in order to
+      check for presence of local fragments since multiple files can use a single
+      fragment.
+      */}}
     {{- $global := .Site.GetPage "page" "_global" -}}
+    {{- $.Scratch.Delete "global_fragments" -}}
     {{- if $global -}}
-      {{- range ($global.Resources.ByType "page") -}}
-        {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.fragment "nav") -}}
-          {{- partial (print "fragments/" .Params.fragment ".html") (dict "tmp_full" $ "Site" $.Site "menus" $.Site.Menus "resources" $.Resources "self" .) -}}
+      {{- $.Scratch.Set "global_fragments" ($global.Resources.ByType "page") -}}
+    {{- end -}}
+    {{- $local_fragments := .Resources.ByType "page" -}}
+  
+    {{- $.Scratch.Set "fragments" (slice .) -}}
+    {{- $.Scratch.Set "local_fragments_dirs" (slice) -}}
+    {{- range $local_fragments -}}
+      {{- $.Scratch.Add "fragments" (slice .) -}}
+      {{- $.Scratch.Add "local_fragments_dirs" .Dir -}}
+    {{- end -}}
+    {{- if $.Scratch.Get "global_fragments" -}}
+      {{- range ($.Scratch.Get "global_fragments") -}}
+        {{- $name := replace .Name "/index" "" -}}
+        {{- $directory_same_name := in ($.Scratch.Get "local_fragments_dirs") (printf "%s%s/" $.Dir (replace $name ".md" "")) -}}
+        {{- $file_same_name := where ($.Scratch.Get "fragments") ".Name" $name -}}
+        {{- if and (not $file_same_name) (not $directory_same_name) -}}
+          {{- $.Scratch.Add "fragments" (slice .) -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}
-
-    <section>
-      <div class="jumbotron text-center mb-0">
-        <img class="img-fluid" src="{{ printf "images/logo.svg" | relURL }}" alt="{{ .Site.Title }}"></img>
-        <h1 class="jumbotron-heading my-5">
-          {{- i18n "404.title" -}}
-        </h1>
-        <h3 class="my-4">
-          {{- i18n "404.subtitle" -}}
-        </h3>
-        <h5 class="my-4">
-          {{- i18n "404.direction" -}}
-        </h5>
-        <a class="btn btn-primary btn-lg my-4" href="/">
-          {{- i18n "404.button" -}}
-        </a>
-      </div>
-    </section>
+  
+    {{- $page := . }}
+    {{ $.Scratch.Set "js" (slice) }}
+    {{- range sort ($.Scratch.Get "fragments" | default slice) "Params.weight" -}}
+      {{- if and (not .Params.disabled) (isset .Params "fragment") -}}
+        {{/* Cleanup .Name to be more useful within fragments */}}
+        {{- $name := strings.TrimSuffix ".md" (replace .Name "/index.md" "") -}}
+  
+        {{/* Resource fallthrough path preparation */}}
+        {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
+        {{- $page_path := replace $file_path (printf "/%s" $name) "" -}}
+        {{- $fallthrough := (dict "file_path" $file_path "page_path" $page_path ) -}}
+  
+        {{- partial (print "fragments/" .Params.fragment ".html") (dict "page_scratch" $.Scratch "root" $ "Site" $.Site "page" $page "resources" $.Resources "self" . "Params" .Params "Name" $name "fallthrough" $fallthrough) -}}
+      {{- end -}}
+    {{- end -}}
 
     {{- partial "js.html" . -}}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,7 +28,7 @@
       {{- $name := replace .Name "/index" "" -}}
       {{- $directory_same_name := in ($.Scratch.Get "local_fragments_dirs") (printf "%s%s/" $.Dir (replace $name ".md" "")) -}}
       {{- $file_same_name := where ($.Scratch.Get "fragments") ".Name" $name -}}
-      {{- if and (not $file_same_name) (not $directory_same_name) -}}
+      {{- if and (not $file_same_name) (not $directory_same_name) (ne .Params.fragment "404") -}}
         {{- $.Scratch.Add "fragments" (slice .) -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/partials/fragments/404.html
+++ b/layouts/partials/fragments/404.html
@@ -1,0 +1,40 @@
+{{ "<!-- 404 -->" | safeHTML }}
+<section>
+  <div class="jumbotron text-center mb-0">
+    {{/* Global resource fallback - can also be used within loops */}}
+    {{- $image := .Params.image | default "logo.svg" -}}
+
+    {{/* Do not change the following snippet */}}
+    {{/* Code is duplicated throughout the code */}}
+    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+    {{/* Page specific resource */}}
+    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+    {{- if (fileExists (printf "content/%s" $location)) -}}
+    {{/* special case index: trim _index/ from url */}}
+    {{- $location := strings.TrimPrefix "_index/" $location -}}
+    {{- $.root.Scratch.Set "image" $location -}}
+    {{- end -}}
+
+    {{/* Fragment specific resource */}}
+    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+    {{- if (fileExists (printf "content/%s" $location)) -}}
+    {{/* special case index: trim _index/ from url */}}
+    {{- $location := strings.TrimPrefix "_index/" $location -}}
+    {{- $.root.Scratch.Set "image" $location -}}
+    {{- end -}}
+    {{/* End of do not change */}}
+    <img class="img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ .Site.Title }}"></img>
+    <h1 class="jumbotron-heading my-5">
+      {{ .Params.title | default (i18n "404.title") }}
+    </h1>
+    <h3 class="my-4">
+      {{ .Params.subtitle | default (i18n "404.subtitle") }}
+    </h3>
+    <h5 class="my-4">
+      {{ .Params.redirect_text | default (i18n "404.direction") }}
+    </h5>
+    <a class="btn btn-primary btn-lg my-4" href="{{ .Params.redirect_url | default "/" }}">
+      {{ .Params.button_text | default (i18n "404.button") }}
+    </a>
+  </div>
+</section>

--- a/static/contact.js
+++ b/static/contact.js
@@ -36,32 +36,17 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
-/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 	};
-/******/
-/******/ 	// create a fake namespace object
-/******/ 	// mode & 1: value is a module id, require it
-/******/ 	// mode & 2: merge all properties of value into the ns
-/******/ 	// mode & 4: return value when already ns object
-/******/ 	// mode & 8|1: behave like require
-/******/ 	__webpack_require__.t = function(value, mode) {
-/******/ 		if(mode & 1) value = __webpack_require__(value);
-/******/ 		if(mode & 8) return value;
-/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
-/******/ 		var ns = Object.create(null);
-/******/ 		__webpack_require__.r(ns);
-/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
-/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
-/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules

--- a/static/hero.js
+++ b/static/hero.js
@@ -36,32 +36,17 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
-/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 	};
-/******/
-/******/ 	// create a fake namespace object
-/******/ 	// mode & 1: value is a module id, require it
-/******/ 	// mode & 2: merge all properties of value into the ns
-/******/ 	// mode & 4: return value when already ns object
-/******/ 	// mode & 8|1: behave like require
-/******/ 	__webpack_require__.t = function(value, mode) {
-/******/ 		if(mode & 1) value = __webpack_require__(value);
-/******/ 		if(mode & 8) return value;
-/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
-/******/ 		var ns = Object.create(null);
-/******/ 		__webpack_require__.r(ns);
-/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
-/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
-/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules

--- a/static/main.js
+++ b/static/main.js
@@ -36,32 +36,17 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
-/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 	};
-/******/
-/******/ 	// create a fake namespace object
-/******/ 	// mode & 1: value is a module id, require it
-/******/ 	// mode & 2: merge all properties of value into the ns
-/******/ 	// mode & 4: return value when already ns object
-/******/ 	// mode & 8|1: behave like require
-/******/ 	__webpack_require__.t = function(value, mode) {
-/******/ 		if(mode & 1) value = __webpack_require__(value);
-/******/ 		if(mode & 8) return value;
-/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
-/******/ 		var ns = Object.create(null);
-/******/ 		__webpack_require__.r(ns);
-/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
-/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
-/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules

--- a/static/portfolio.js
+++ b/static/portfolio.js
@@ -36,32 +36,17 @@
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
-/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 	};
-/******/
-/******/ 	// create a fake namespace object
-/******/ 	// mode & 1: value is a module id, require it
-/******/ 	// mode & 2: merge all properties of value into the ns
-/******/ 	// mode & 4: return value when already ns object
-/******/ 	// mode & 8|1: behave like require
-/******/ 	__webpack_require__.t = function(value, mode) {
-/******/ 		if(mode & 1) value = __webpack_require__(value);
-/******/ 		if(mode & 8) return value;
-/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
-/******/ 		var ns = Object.create(null);
-/******/ 		__webpack_require__.r(ns);
-/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
-/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
-/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules


### PR DESCRIPTION
**What this PR does / why we need it**:
Make 404 page support fragments by creating a 404 fragment (same as the previous layout) and adding that fragment to the global fragments. 404 fragment will not be loaded anywhere except the 404 page if it's added in the global directory.

**Special notes for your reviewer**:

**Release note**:
```release-note
404 page is now customizable using fragments
```
