### PR TITLE
Fix issues with no image in portfolio and member fragments

### DIFF
--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -46,39 +46,41 @@
           {{- range $members -}}
             {{/* Handle special case of index.md being considered a member */}}
             {{- if not (in .Name "/index.md") -}}
-              {{/* Global resource fallback - can also be used within loops */}}
-              {{- $image := .Params.image -}}
-
-              {{/* Do not change the following snippet */}}
-              {{/* Code is duplicated throughout the code */}}
-              {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-              {{/* Page specific resource */}}
-              {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-              {{- if (fileExists (printf "content/%s" $location)) -}}
-              {{/* special case index: trim _index/ from url */}}
-              {{- $location := strings.TrimPrefix "_index/" $location -}}
-              {{- $.root.Scratch.Set "image" $location -}}
-              {{- end -}}
-
-              {{/* Fragment specific resource */}}
-              {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-              {{- if (fileExists (printf "content/%s" $location)) -}}
-              {{/* special case index: trim _index/ from url */}}
-              {{- $location := strings.TrimPrefix "_index/" $location -}}
-              {{- $.root.Scratch.Set "image" $location -}}
-              {{- end -}}
-              {{/* End of do not change */}}
               {{- $member := .Params -}}
               <div class="col-lg-4 col-md-6 col-sm-12 pt-3 pb-5 text-left text-sm-center">
-                <div class="text-center m-2">
-                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle w-75 border
-                    {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-                      {{- printf " border-%s" "dark" -}}
-                    {{- else -}}
-                      {{- printf " border-%s" "white" -}}
-                    {{- end -}}
-                  " alt=""></img>
-                </div>
+                {{- if .Params.image -}}
+                  {{/* Global resource fallback - can also be used within loops */}}
+                  {{- $image := .Params.image -}}
+    
+                  {{/* Do not change the following snippet */}}
+                  {{/* Code is duplicated throughout the code */}}
+                  {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+                  {{/* Page specific resource */}}
+                  {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+                  {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                  {{- end -}}
+    
+                  {{/* Fragment specific resource */}}
+                  {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+                  {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                  {{- end -}}
+                  {{/* End of do not change */}}
+                  <div class="text-center m-2">
+                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle w-75 border
+                      {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
+                        {{- printf " border-%s" "dark" -}}
+                      {{- else -}}
+                        {{- printf " border-%s" "white" -}}
+                      {{- end -}}
+                    " alt=""></img>
+                  </div>
+                {{- end -}}
                 <div class="mt-5 mb-0
                   {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                     {{- printf " text-%s" "dark" -}}
@@ -151,45 +153,55 @@
         </div>
       {{- else if le $members 1 -}}
         <div class="card p-2">
-          <div class="row m-0 justify-content-center align-items-center">
+          <div class="row m-0 justify-content-center 
+            {{- if .Params.image -}}
+              {{- printf " align-items-center" -}}
+            {{- end -}}">
             {{- range $members -}}
               {{/* Handle special case of index.md being considered a member */}}
               {{- if not (in .Name "/index.md") -}}
-                {{/* Global resource fallback - can also be used within loops */}}
-                {{- $image := .Params.image -}}
-
-                {{/* Do not change the following snippet */}}
-                {{/* Code is duplicated throughout the code */}}
-                {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-                {{/* Page specific resource */}}
-                {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                {{- if (fileExists (printf "content/%s" $location)) -}}
-                {{/* special case index: trim _index/ from url */}}
-                {{- $location := strings.TrimPrefix "_index/" $location -}}
-                {{- $.root.Scratch.Set "image" $location -}}
-                {{- end -}}
-
-                {{/* Fragment specific resource */}}
-                {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                {{- if (fileExists (printf "content/%s" $location)) -}}
-                {{/* special case index: trim _index/ from url */}}
-                {{- $location := strings.TrimPrefix "_index/" $location -}}
-                {{- $.root.Scratch.Set "image" $location -}}
-                {{- end -}}
-                {{/* End of do not change */}}
                 {{- $member := .Params -}}
-                <div class="col-12 col-lg-4 p-4 text-center">
-                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle border
-                    {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-                      {{- printf " border-%s" "dark" -}}
-                    {{- else -}}
-                      {{- printf " border-%s" "white" -}}
-                    {{- end -}}
-                  " alt=""></img>
-                </div>
-                <div class="col-12 col-lg-8 pb-4 pt-0 pl-lg-5 pt-lg-4 text-center text-lg-left">
-                  <div class="member
+                {{- if .Params.image -}}
+                  {{/* Global resource fallback - can also be used within loops */}}
+                  {{- $image := .Params.image -}}
+
+                  {{/* Do not change the following snippet */}}
+                  {{/* Code is duplicated throughout the code */}}
+                  {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+
+                  {{/* Page specific resource */}}
+                  {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+                  {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                  {{- end -}}
+
+                  {{/* Fragment specific resource */}}
+                  {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+                  {{- if (fileExists (printf "content/%s" $location)) -}}
+                  {{/* special case index: trim _index/ from url */}}
+                  {{- $location := strings.TrimPrefix "_index/" $location -}}
+                  {{- $.root.Scratch.Set "image" $location -}}
+                  {{- end -}}
+                  {{/* End of do not change */}}
+                  <div class="col-12 col-lg-4 p-4 text-center">
+                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle border
+                      {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
+                        {{- printf " border-%s" "dark" -}}
+                      {{- else -}}
+                        {{- printf " border-%s" "white" -}}
+                      {{- end -}}
+                    " alt=""></img>
+                  </div>
+                {{- end -}}
+                <div class="col-12 text-lg-left
+                  {{- if .Params.image -}}
+                    {{- printf " col-lg-8 pb-4 pt-0 pl-lg-5 pt-lg-4 text-center" -}}
+                  {{- else -}}
+                    {{- printf " col-lg-4" -}}
+                  {{- end -}}">
+                  <div class="member text-center text-lg-left
                     {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
                       {{- printf " text-%s" "dark" -}}
                     {{- else -}}
@@ -250,10 +262,15 @@
                     {{- end -}}
                   </div>
                 </div>
-                {{- with .Content -}}
-                  <div class="col-12 p-4 text-center text-lg-left">
+                {{- if .Content -}}
+                  <div class="col-12 text-center text-lg-left
+                    {{- if .Params.image -}}
+                      {{- printf " p-4" -}}
+                    {{- else -}}
+                      {{- printf " col-lg-8 pt-0 pl-lg-5 text-center" -}}
+                    {{- end -}}">
                     <div class="description">
-                      {{- . | markdownify -}}
+                      {{- .Content | markdownify -}}
                     </div>
                   </div>
                 {{- end -}}

--- a/static-main/styles/_portfolio.scss
+++ b/static-main/styles/_portfolio.scss
@@ -1,4 +1,6 @@
 .portfolio-item {
+  min-height: 110px;
+
   .description {
     background-color: rgba($dark, 0.6);
     transition: $transition-base;

--- a/static/syna-main.css
+++ b/static/syna-main.css
@@ -9625,37 +9625,35 @@ div.form-error ul li {
     display: block;
     width: 256px; } }
 
-.portfolio-item .description {
-  background-color: rgba(52, 58, 64, 0.6);
-  transition: all 0.2s ease-in-out; }
-  .portfolio-item .description-container {
+.portfolio-item {
+  min-height: 110px; }
+  .portfolio-item .description {
+    background-color: rgba(52, 58, 64, 0.6);
+    transition: all 0.2s ease-in-out; }
+    .portfolio-item .description-container {
+      bottom: 8px;
+      left: 8px;
+      width: calc(100% - 16px); }
+    .portfolio-item .description .title {
+      font-weight: bold; }
+  .portfolio-item * {
+    cursor: pointer; }
+  .portfolio-item .hover-overlay {
     bottom: 8px;
-    left: 8px;
-    width: calc(100% - 16px); }
-  .portfolio-item .description .title {
-    font-weight: bold; }
-
-.portfolio-item * {
-  cursor: pointer; }
-
-.portfolio-item .hover-overlay {
-  bottom: 8px;
-  left: 16px;
-  width: calc(100% - 16px);
-  height: 32px;
-  border-radius: 4;
-  transition: all 0.2s ease-in-out; }
-
-.portfolio-item:hover .description {
-  background: rgba(52, 58, 64, 0); }
-
-.portfolio-item:hover .hover-overlay {
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 0;
-  background-color: rgba(52, 58, 64, 0.6); }
+    left: 16px;
+    width: calc(100% - 16px);
+    height: 32px;
+    border-radius: 4;
+    transition: all 0.2s ease-in-out; }
+  .portfolio-item:hover .description {
+    background: rgba(52, 58, 64, 0); }
+  .portfolio-item:hover .hover-overlay {
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+    background-color: rgba(52, 58, 64, 0.6); }
 
 .pricing-plan {
   display: flex; }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issues with member and portfolio fragments when image is not provided. I don't like portfolio. The background solution is not pretty frankly. Let me know what you think.

**Special notes for your reviewer**:
Single member with image:

![image](https://user-images.githubusercontent.com/14017717/43994359-d43796ac-9db0-11e8-94c2-4d7625ea8113.png)

![image](https://user-images.githubusercontent.com/14017717/43994363-e9d9005e-9db0-11e8-9ff5-85739b40abbe.png)

Single member with no image:

![image](https://user-images.githubusercontent.com/14017717/43994367-ff4d827a-9db0-11e8-91ab-c52f4242a7df.png)

![image](https://user-images.githubusercontent.com/14017717/43994369-094253dc-9db1-11e8-8f47-656df205f89a.png)

Member with image:

![image](https://user-images.githubusercontent.com/14017717/43994370-15cfdba6-9db1-11e8-9cd9-36885f8de1d3.png)

Member with no image:

![image](https://user-images.githubusercontent.com/14017717/43994395-7e21bc7e-9db1-11e8-8251-6631487141a6.png)

Portfolio with image:

![image](https://user-images.githubusercontent.com/14017717/43994403-8b2543c8-9db1-11e8-8c29-a83ae6d78efb.png)

Portfolio with no image:

![image](https://user-images.githubusercontent.com/14017717/43994411-9f8e4a12-9db1-11e8-91e3-5acfdc41628a.png)

**Release note**:
```release-note
- portfolio: Fix the size of the item with no image
- member: Remove image and realign data when no image is available for the item
```
