### PR TITLE
Fix default section in list fragment

### DIFF
--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -3,7 +3,11 @@
   where functions achieving this. First where gets all the pages in blog
   section, the second one removes current page from the mix and the last one
   removes the section (.Site.Pages returns the current section as a page). */}}
-{{- $pages := where (where .Site.Pages.ByDate "Section" (.Params.section | default .page.Section)) "Params.fragment" "eq" "content" -}}
+{{- .page_scratch.Set "pages" (where .Site.Pages.ByDate "Section" (.Params.section | default .root.Section)) -}}
+{{- if and (not .Params.section) (eq .root.CurrentSection.Kind "section") -}}
+  {{- .page_scratch.Set "pages" (.root.CurrentSection.Pages) -}}
+{{- end -}}
+{{- $pages := where (.page_scratch.Get "pages") "Params.fragment" "eq" "content" -}}
 {{- $self := . -}}
 {{- $bg := .Params.background | default "light" }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix list fragment not showing the pages of a nested section

**Which issue this PR fixes**:
fixes #296 

**Special notes for your reviewer**:

**Release note**:
```release-note
- list: Fix section variable default value for nested sections
```
