### PR TITLE
Display an error message in portfolio when no item is available

### DIFF
--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -39,53 +39,61 @@
         </div>
       {{- end }}
       <div class="row">
-        {{- range (sort $items ".Params.weight") }}
-          <div class="col-lg-4 col-md-6 col-12 py-2">
-            <div class="border rounded position-relative portfolio-item overflow-hidden 
-              {{- if not .Params.url }} has-modal {{- end -}}
-            ">
-              {{- if .Params.url }}
-                <a href="{{ .Params.url | relURL }}">
-              {{- end }}
-                  {{/* Global resource fallback - can also be used within loops */}}
-                  {{- $image := .Params.image -}}
-        
-                  {{/* Do not change the following snippet */}}
-                  {{/* Code is duplicated throughout the code */}}
-                  {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-        
-                  {{/* Page specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                    {{/* special case index: trim _index/ from url */}}
-                    {{- $location := strings.TrimPrefix "_index/" $location -}}
-                    {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-        
-                  {{/* Fragment specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                    {{/* special case index: trim _index/ from url */}}
-                    {{- $location := strings.TrimPrefix "_index/" $location -}}
-                    {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-                  {{/* End of do not change */}}
-                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid" alt="{{ .Params.title }}">
-                  <div class="position-absolute hover-overlay"></div>
-                  {{- if or .Params.title .Params.subtitle }}
-                    <div class="position-absolute description-container col">
-                      <div class="row justify-content-center description text-light p-2 rounded text-center">
-                        {{ if .Params.title }}<h5 class="title">{{ .Params.title }}</h5>{{ end }}
-                        {{ if .Params.subtitle }}<h6 class="subtitle">{{ .Params.subtitle }}</h6>{{ end }}
-                      </div>
-                    </div>
-                  {{- end }}
-                  <div class="content hidden">{{ .Content }}</div>
-              {{- if .Params.url }}
-                </a>
-              {{- end }}
+        {{- if eq (len $items) 0 }}
+          <div class="row w-100 justify-content-center">
+            <div class="alert alert-danger text-center">
+              {{- printf "Currently there is no configured portfolio content files present. To add new item add a content file within %s" $.fallthrough.file_path -}}
             </div>
           </div>
+        {{- else -}}
+          {{- range (sort $items ".Params.weight") }}
+            <div class="col-lg-4 col-md-6 col-12 py-2">
+              <div class="border rounded position-relative portfolio-item overflow-hidden 
+                {{- if not .Params.url }} has-modal {{- end -}}
+              ">
+                {{- if .Params.url }}
+                  <a href="{{ .Params.url | relURL }}">
+                {{- end }}
+                    {{/* Global resource fallback - can also be used within loops */}}
+                    {{- $image := .Params.image -}}
+          
+                    {{/* Do not change the following snippet */}}
+                    {{/* Code is duplicated throughout the code */}}
+                    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+          
+                    {{/* Page specific resource */}}
+                    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+                    {{- if (fileExists (printf "content/%s" $location)) -}}
+                      {{/* special case index: trim _index/ from url */}}
+                      {{- $location := strings.TrimPrefix "_index/" $location -}}
+                      {{- $.root.Scratch.Set "image" $location -}}
+                    {{- end -}}
+          
+                    {{/* Fragment specific resource */}}
+                    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+                    {{- if (fileExists (printf "content/%s" $location)) -}}
+                      {{/* special case index: trim _index/ from url */}}
+                      {{- $location := strings.TrimPrefix "_index/" $location -}}
+                      {{- $.root.Scratch.Set "image" $location -}}
+                    {{- end -}}
+                    {{/* End of do not change */}}
+                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid" alt="{{ .Params.title }}">
+                    <div class="position-absolute hover-overlay"></div>
+                    {{- if or .Params.title .Params.subtitle }}
+                      <div class="position-absolute description-container col">
+                        <div class="row justify-content-center description text-light p-2 rounded text-center">
+                          {{ if .Params.title }}<h5 class="title">{{ .Params.title }}</h5>{{ end }}
+                          {{ if .Params.subtitle }}<h6 class="subtitle">{{ .Params.subtitle }}</h6>{{ end }}
+                        </div>
+                      </div>
+                    {{- end }}
+                    <div class="content hidden">{{ .Content }}</div>
+                {{- if .Params.url }}
+                  </a>
+                {{- end }}
+              </div>
+            </div>
+          {{- end -}}
         {{- end }}
       </div>
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Display an error message in portfolio when no item is available

**Which issue this PR fixes**:
fixes #285 

**Release note**:
```release-note
- portfolio: Display error message when no item is configured
```
