### PR TITLE
Add ability to resize 404 image size

### DIFF
--- a/exampleSite/content/_global/404.md
+++ b/exampleSite/content/_global/404.md
@@ -8,4 +8,9 @@ weight = 150
 #redirect_text = "" # default i18n "404.direction"
 #button_text = "" # default i18n "404.button"
 #redirect_url = "" # default /
+
+[logo]
+  image = "logo.svg"
+  width = "500px" # optional - will default to image width
+  #height = "150px" # optional - will default to image height
 +++

--- a/layouts/partials/fragments/404.html
+++ b/layouts/partials/fragments/404.html
@@ -1,29 +1,36 @@
+{{- $self := . }}
+
 {{ "<!-- 404 -->" | safeHTML }}
 <section>
   <div class="jumbotron text-center mb-0">
-    {{/* Global resource fallback - can also be used within loops */}}
-    {{- $image := .Params.image | default "logo.svg" -}}
+    {{- with (.Params.logo | default (dict "image" "logo.svg")) -}}
+      {{/* Global resource fallback - can also be used within loops */}}
+      {{- $image := .image -}}
 
-    {{/* Do not change the following snippet */}}
-    {{/* Code is duplicated throughout the code */}}
-    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-    {{/* Page specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-    {{/* special case index: trim _index/ from url */}}
-    {{- $location := strings.TrimPrefix "_index/" $location -}}
-    {{- $.root.Scratch.Set "image" $location -}}
-    {{- end -}}
+      {{/* Do not change the following snippet */}}
+      {{/* Code is duplicated throughout the code */}}
+      {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+      {{/* Page specific resource */}}
+      {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+      {{- if (fileExists (printf "content/%s" $location)) -}}
+      {{/* special case index: trim _index/ from url */}}
+      {{- $location := strings.TrimPrefix "_index/" $location -}}
+      {{- $.root.Scratch.Set "image" $location -}}
+      {{- end -}}
 
-    {{/* Fragment specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-    {{/* special case index: trim _index/ from url */}}
-    {{- $location := strings.TrimPrefix "_index/" $location -}}
-    {{- $.root.Scratch.Set "image" $location -}}
+      {{/* Fragment specific resource */}}
+      {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+      {{- if (fileExists (printf "content/%s" $location)) -}}
+      {{/* special case index: trim _index/ from url */}}
+      {{- $location := strings.TrimPrefix "_index/" $location -}}
+      {{- $.root.Scratch.Set "image" $location -}}
+      {{- end -}}
+      {{/* End of do not change */}}
+      <img class="img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ $self.Site.Title }}"
+        {{- if .height -}} height="{{ .height }}"{{- end -}}
+        {{- if .width -}} width="{{ .width }}"{{- end -}}
+      ></img>
     {{- end -}}
-    {{/* End of do not change */}}
-    <img class="img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ .Site.Title }}"></img>
     <h1 class="jumbotron-heading my-5">
       {{ .Params.title | default (i18n "404.title") }}
     </h1>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ability to add images for 404 and ability to resize them. The default image for 404 fragment is logo.svg.

**Which issue this PR fixes**:
fixes #278 

**Release note**:
```release-note
- 404: Add ability to change and resize image
```
