### PR TITLE
Add new helper for image fallthrough

### DIFF
--- a/exampleSite/content/_global/404.md
+++ b/exampleSite/content/_global/404.md
@@ -9,7 +9,7 @@ weight = 150
 #button_text = "" # default i18n "404.button"
 #redirect_url = "" # default /
 
-[logo]
+[asset]
   image = "logo.svg"
   width = "500px" # optional - will default to image width
   #height = "150px" # optional - will default to image height

--- a/exampleSite/content/_global/footer.md
+++ b/exampleSite/content/_global/footer.md
@@ -7,7 +7,7 @@ background = "secondary"
 
 menu_title = "Further Resources"
 
-[logo]
+[asset]
   image = "logo.svg"
   text = "Logo Subtext"
 +++

--- a/exampleSite/content/_global/nav.md
+++ b/exampleSite/content/_global/nav.md
@@ -6,7 +6,7 @@ weight = 0
 #background = ""
 
 # Branding options
-[branding]
+[asset]
   image = "logo.svg"
   text = "Syna"
 

--- a/exampleSite/content/_index/hero/index.md
+++ b/exampleSite/content/_index/hero/index.md
@@ -8,9 +8,11 @@ particles = true
 
 title = "Syna Theme"
 subtitle = "Showcase your next project"
-header = "header.jpg"
 
-[logo]
+[header]
+  image = "header.jpg"
+
+[asset]
   image = "logo.svg"
   width = "500px" # optional - will default to image width
   #height = "150px" # optional - will default to image height

--- a/exampleSite/content/dev/missing-images/footer.md
+++ b/exampleSite/content/dev/missing-images/footer.md
@@ -3,7 +3,7 @@ fragment = "footer"
 date = "2016-09-07"
 weight = 1200
 
-[logo]
+[asset]
   title = "Logo Title"
   image = "404.png"
   text = "Logo Subtext"

--- a/exampleSite/content/dev/missing-images/hero/index.md
+++ b/exampleSite/content/dev/missing-images/hero/index.md
@@ -6,9 +6,11 @@ particles = true
 
 title = "title"
 subtitle = "subtitle"
-header = "404.png"
 
-[logo]
+[header]
+  image = "404.png"
+
+[asset]
   image = "404.png"
 
 [[buttons]]

--- a/exampleSite/content/dev/missing-images/item_image-right.md
+++ b/exampleSite/content/dev/missing-images/item_image-right.md
@@ -11,7 +11,8 @@ subtitle= "image right"
 pre = "pre"
 post = "post"
 
-image = "404.png"
+[asset]
+  image = "404.png"
 +++
 
 Some more text to showcase the description capabilities:

--- a/exampleSite/content/dev/missing-images/logos.md
+++ b/exampleSite/content/dev/missing-images/logos.md
@@ -5,19 +5,19 @@ weight = 300
 
 title = "logo"
 
-[[logos]]
+[[assets]]
   text = "1"
   weight = 10
   image = "404.png"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "2"
   weight = 20
   image = "404.png"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "3"
   weight = 30
   image = "404.png"

--- a/exampleSite/content/dev/missing-images/member-single/bio.md
+++ b/exampleSite/content/dev/missing-images/member-single/bio.md
@@ -2,9 +2,12 @@
   title = "Huge Gopher"
   weight = 0
   date = "2017-10-17"
-  image = "404.png"
+
   position = "Lead Gopherineer"
   company = "Okkur Labs"
+
+  [asset]
+    image = "404.png"
 
   reports_to = "CTO"
   lives_in = "[Munich, Germany](https://www.google.com/maps/place/Munich,+Germany/)"

--- a/exampleSite/content/dev/missing-images/member/donald.md
+++ b/exampleSite/content/dev/missing-images/member/donald.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 4"
 weight = 30
 date = "2017-10-17"
 
-image = "404.png"
+[asset]
+  image = "404.png"
+
 position = "Gopherineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 scope = [

--- a/exampleSite/content/dev/missing-images/member/ella.md
+++ b/exampleSite/content/dev/missing-images/member/ella.md
@@ -3,7 +3,9 @@ title = "Huge Gopher"
 weight = 0
 date = "2017-10-17"
 
-image = "404.png"
+[asset]
+  image = "404.png"
+
 position = "Lead Gopherineer"
 reports_to = "CTO"
 lives_in = "[Munich, Germany](https://www.google.com/maps/place/Munich,+Germany/)"

--- a/exampleSite/content/dev/missing-images/member/gopher.md
+++ b/exampleSite/content/dev/missing-images/member/gopher.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher"
 weight = 10
 date = "2017-10-17"
 
-image = "404.png"
+[asset]
+  image = "404.png"
+
 position = "Gopherineer"
 reports_to = "Lead Gophineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"

--- a/exampleSite/content/dev/missing-images/member/hector.md
+++ b/exampleSite/content/dev/missing-images/member/hector.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 5"
 weight = 30
 date = "2017-10-17"
 
-image = "404.png"
+[asset]
+  image = "404.png"
+
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 
 [[icons]]

--- a/exampleSite/content/dev/missing-images/nav.md
+++ b/exampleSite/content/dev/missing-images/nav.md
@@ -4,7 +4,7 @@ date = "2018-05-17"
 weight = 0
 
 # Branding options
-[branding]
+[asset]
   image = "404.png"
   text = "Syna"
 

--- a/exampleSite/content/dev/missing-images/portfolio/item1.md
+++ b/exampleSite/content/dev/missing-images/portfolio/item1.md
@@ -2,8 +2,10 @@
 weight = 10
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "404.png"
 url = "#"
+
+[asset]
+  image = "404.png"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/missing-images/portfolio/item2.md
+++ b/exampleSite/content/dev/missing-images/portfolio/item2.md
@@ -2,7 +2,9 @@
 weight = 20
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "404.png"
+
+[asset]
+  image = "404.png"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/missing-images/portfolio/item3.md
+++ b/exampleSite/content/dev/missing-images/portfolio/item3.md
@@ -2,7 +2,9 @@
 weight = 30
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "404.png"
+
+[asset]
+  image = "404.png"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/missing-images/portfolio/item4.md
+++ b/exampleSite/content/dev/missing-images/portfolio/item4.md
@@ -1,6 +1,8 @@
 +++
 weight = 40
-image = "404.png"
+
+[asset]
+  image = "404.png"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/fragment/footer/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/footer/index.md
@@ -3,7 +3,7 @@ fragment = "footer"
 date = "2016-09-07"
 weight = 1200
 
-[logo]
+[asset]
   title = "logo"
   image = "resource_logo.svg"
   text = "alt text"

--- a/exampleSite/content/dev/resource-fallthrough/fragment/hero/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/hero/index.md
@@ -6,8 +6,10 @@ particles = true
 
 title = "title"
 subtitle = "subtitle"
-header = "resource_logo.svg"
 
-[logo]
+[header]
+  image = "resource_logo.svg"
+
+[asset]
   image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/fragment/item/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/item/index.md
@@ -6,5 +6,6 @@ align = "center"
 
 title = "item"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/fragment/logos/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/logos/index.md
@@ -6,7 +6,7 @@ background = "dark"
 
 title = "logos"
 
-[[logos]]
+[[assets]]
   name = "syna"
   weight = 10
   image = "resource_logo.svg"

--- a/exampleSite/content/dev/resource-fallthrough/fragment/member/gopher.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/member/gopher.md
@@ -3,7 +3,8 @@ title = "Tiny Gopher"
 weight = 10
 date = "2017-10-17"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/exampleSite/content/dev/resource-fallthrough/fragment/nav/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/nav/index.md
@@ -3,7 +3,7 @@ fragment = "nav"
 date = "2018-05-17"
 weight = 0
 
-[branding]
+[asset]
   image = "resource_logo.svg"
   text = "Syna"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item1.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item1.md
@@ -2,8 +2,10 @@
 weight = 10
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
 url = "#"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item2.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item2.md
@@ -2,7 +2,9 @@
 weight = 20
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item3.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/portfolio/item3.md
@@ -2,7 +2,9 @@
 weight = 30
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/global/footer/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/footer/index.md
@@ -3,7 +3,7 @@ fragment = "footer"
 date = "2016-09-07"
 weight = 1200
 
-[logo]
+[asset]
   title = "logo"
   image = "resource_logo.svg"
   text = "alt text"

--- a/exampleSite/content/dev/resource-fallthrough/global/hero/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/hero/index.md
@@ -6,8 +6,10 @@ particles = true
 
 title = "title"
 subtitle = "subtitle"
-header = "resource_logo.svg"
 
-[logo]
+[header]
+  image = "resource_logo.svg"
+
+[asset]
   image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/global/item/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/item/index.md
@@ -6,5 +6,6 @@ align = "center"
 
 title = "item"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/global/logos/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/logos/index.md
@@ -6,7 +6,7 @@ background = "dark"
 
 title = "logos"
 
-[[logos]]
+[[assets]]
   name = "syna"
   weight = 10
   image = "resource_logo.svg"

--- a/exampleSite/content/dev/resource-fallthrough/global/member/gopher.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/member/gopher.md
@@ -3,7 +3,8 @@ title = "Tiny Gopher"
 weight = 10
 date = "2017-10-17"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/exampleSite/content/dev/resource-fallthrough/global/nav/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/nav/index.md
@@ -3,7 +3,7 @@ fragment = "nav"
 date = "2018-05-17"
 weight = 0
 
-[branding]
+[asset]
   image = "resource_logo.svg"
   text = "Syna"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/global/portfolio/item1.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/portfolio/item1.md
@@ -2,8 +2,10 @@
 weight = 10
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
 url = "#"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/global/portfolio/item2.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/portfolio/item2.md
@@ -2,7 +2,9 @@
 weight = 20
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/global/portfolio/item3.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/portfolio/item3.md
@@ -2,7 +2,9 @@
 weight = 30
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/page/footer/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/footer/index.md
@@ -3,7 +3,7 @@ fragment = "footer"
 date = "2016-09-07"
 weight = 1200
 
-[logo]
+[asset]
   title = "logo"
   image = "resource_logo.svg"
   text = "alt text"

--- a/exampleSite/content/dev/resource-fallthrough/page/hero/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/hero/index.md
@@ -6,8 +6,10 @@ particles = true
 
 title = "title"
 subtitle = "subtitle"
-header = "resource_logo.svg"
 
-[logo]
+[header]
+  image = "resource_logo.svg"
+
+[asset]
   image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/page/item/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/item/index.md
@@ -6,5 +6,6 @@ align = "center"
 
 title = "item"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/page/logos/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/logos/index.md
@@ -6,7 +6,7 @@ background = "dark"
 
 title = "logos"
 
-[[logos]]
+[[assets]]
   name = "syna"
   weight = 10
   image = "resource_logo.svg"

--- a/exampleSite/content/dev/resource-fallthrough/page/member/gopher.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/member/gopher.md
@@ -3,7 +3,8 @@ title = "Tiny Gopher"
 weight = 10
 date = "2017-10-17"
 
-image = "resource_logo.svg"
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/exampleSite/content/dev/resource-fallthrough/page/nav/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/nav/index.md
@@ -3,7 +3,7 @@ fragment = "nav"
 date = "2018-05-17"
 weight = 0
 
-[branding]
+[asset]
   image = "resource_logo.svg"
   text = "Syna"
 +++

--- a/exampleSite/content/dev/resource-fallthrough/page/portfolio/item1.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/portfolio/item1.md
@@ -2,8 +2,10 @@
 weight = 10
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
 url = "#"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/page/portfolio/item2.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/portfolio/item2.md
@@ -2,7 +2,9 @@
 weight = 20
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/resource-fallthrough/page/portfolio/item3.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/portfolio/item3.md
@@ -2,7 +2,9 @@
 weight = 30
 title = "title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "resource_logo.svg"
+
+[asset]
+  image = "resource_logo.svg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/dev/unconfigured-images/footer.md
+++ b/exampleSite/content/dev/unconfigured-images/footer.md
@@ -3,7 +3,7 @@ fragment = "footer"
 date = "2016-09-07"
 weight = 1200
 
-[logo]
+[asset]
   title = "Logo Title"
   text = "Logo Subtext"
   url = "#"

--- a/exampleSite/content/dev/unconfigured-images/logos.md
+++ b/exampleSite/content/dev/unconfigured-images/logos.md
@@ -5,17 +5,17 @@ weight = 300
 
 title = "logo"
 
-[[logos]]
+[[assets]]
   text = "1"
   weight = 10
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "2"
   weight = 20
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "3"
   weight = 30
   url = "#"

--- a/exampleSite/content/dev/unconfigured-images/nav.md
+++ b/exampleSite/content/dev/unconfigured-images/nav.md
@@ -4,7 +4,7 @@ date = "2018-05-17"
 weight = 0
 
 # Branding options
-[branding]
+[asset]
   text = "Syna"
 
 [repo_button]

--- a/exampleSite/content/fragments/footer/code-footer-example.md
+++ b/exampleSite/content/fragments/footer/code-footer-example.md
@@ -14,7 +14,7 @@ background = "secondary"
 
 menu_title = "Link Title"
 
-[logo]
+[asset]
   title = "Logo Title"
   image = "logo.svg"
   text = "Logo Subtext"

--- a/exampleSite/content/fragments/footer/footer-example.md
+++ b/exampleSite/content/fragments/footer/footer-example.md
@@ -7,7 +7,7 @@ background = "secondary"
 
 menu_title = "Link Title"
 
-[logo]
+[asset]
   title = "Logo Title"
   image = "logo.svg"
   text = "Logo Subtext"

--- a/exampleSite/content/fragments/hero/code-hero.md
+++ b/exampleSite/content/fragments/hero/code-hero.md
@@ -15,9 +15,11 @@ particles = true
 
 title = "Syna Theme"
 subtitle = "Showcase your next project"
-header = "header.jpg"
 
-[logo]
+[header]
+  image = "header.jpg"
+
+[asset]
   image = "logo.svg"
   width = "500px" # optional - will default to image width
   #height = "150px" # optional - will default to image height

--- a/exampleSite/content/fragments/hero/hero/index.md
+++ b/exampleSite/content/fragments/hero/hero/index.md
@@ -8,9 +8,11 @@ particles = true
 
 title = "Syna Theme"
 subtitle = "Showcase your next project"
-header = "header.jpg"
 
-[logo]
+[header]
+  image = "header.jpg"
+
+[asset]
   image = "logo.svg"
   width = "500px" # optional - will default to image width
   #height = "150px" # optional - will default to image height

--- a/exampleSite/content/fragments/item/code-item_image-button-left.md
+++ b/exampleSite/content/fragments/item/code-item_image-button-left.md
@@ -20,7 +20,8 @@ title = "Item Fragment Image Button Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 
 [[buttons]]
   text = "Button"

--- a/exampleSite/content/fragments/item/code-item_image-center.md
+++ b/exampleSite/content/fragments/item/code-item_image-center.md
@@ -20,7 +20,8 @@ title = "Item Fragment Image Center"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++
 
 

--- a/exampleSite/content/fragments/item/code-item_image-only.md
+++ b/exampleSite/content/fragments/item/code-item_image-only.md
@@ -20,7 +20,8 @@ title = "Item Fragment Image Only"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/item/code-item_image-right.md
+++ b/exampleSite/content/fragments/item/code-item_image-right.md
@@ -20,7 +20,8 @@ subtitle= "Easily right align the item fragment even with an image"
 pre = "Awesome screenshot"
 post = "Showcasing Syna"
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++
 
 Easily left align the item fragment even with an image and buttons at the same time.

--- a/exampleSite/content/fragments/item/code-item_image-table-left.md
+++ b/exampleSite/content/fragments/item/code-item_image-table-left.md
@@ -20,7 +20,8 @@ title = "Item Fragment Image Table Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 
 [header]
   [[header.values]]

--- a/exampleSite/content/fragments/item/item_image-button-left.md
+++ b/exampleSite/content/fragments/item/item_image-button-left.md
@@ -13,7 +13,8 @@ title = "Item Fragment Image Button Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 
 [[buttons]]
   text = "Button"

--- a/exampleSite/content/fragments/item/item_image-center.md
+++ b/exampleSite/content/fragments/item/item_image-center.md
@@ -13,7 +13,8 @@ title = "Item Fragment Image Center"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++
 
 

--- a/exampleSite/content/fragments/item/item_image-only.md
+++ b/exampleSite/content/fragments/item/item_image-only.md
@@ -13,5 +13,6 @@ title = "Item Fragment Image Only"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++

--- a/exampleSite/content/fragments/item/item_image-right.md
+++ b/exampleSite/content/fragments/item/item_image-right.md
@@ -13,7 +13,8 @@ subtitle= "Easily right align the item fragment even with an image"
 pre = "Awesome screenshot"
 post = "Showcasing Syna"
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 +++
 
 Easily left align the item fragment even with an image and buttons at the same time.

--- a/exampleSite/content/fragments/item/item_image-table-left.md
+++ b/exampleSite/content/fragments/item/item_image-table-left.md
@@ -13,7 +13,8 @@ title = "Item Fragment Image Table Left"
 #pre = ""
 #post = ""
 
-image = "screenshot.png"
+[asset]
+  image = "screenshot.png"
 
 [header]
   [[header.values]]

--- a/exampleSite/content/fragments/logos/code-logos.md
+++ b/exampleSite/content/fragments/logos/code-logos.md
@@ -15,19 +15,19 @@ background = "secondary"
 title = "Logo Fragment"
 subtitle = "Even linking is possible"
 
-[[logos]]
+[[assets]]
   text = "hugo"
   weight = 20
   image = "hugo.svg"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "go"
   weight = 10
   image = "go.svg"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "caddy"
   weight = 30
   image = "caddy.svg"

--- a/exampleSite/content/fragments/logos/code-logos_only.md
+++ b/exampleSite/content/fragments/logos/code-logos_only.md
@@ -15,7 +15,7 @@ background = "secondary"
 #title = ""
 #subtitle = ""
 
-[[logos]]
+[[assets]]
   text = "syna"
   weight = 10
   image = "syna.svg"

--- a/exampleSite/content/fragments/logos/logos.md
+++ b/exampleSite/content/fragments/logos/logos.md
@@ -8,19 +8,19 @@ background = "secondary"
 title = "Logo Fragment"
 subtitle = "Even linking is possible"
 
-[[logos]]
+[[assets]]
   text = "hugo"
   weight = 20
   image = "hugo.svg"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "go"
   weight = 10
   image = "go.svg"
   url = "#"
 
-[[logos]]
+[[assets]]
   text = "caddy"
   weight = 30
   image = "caddy.svg"

--- a/exampleSite/content/fragments/logos/logos_only.md
+++ b/exampleSite/content/fragments/logos/logos_only.md
@@ -8,7 +8,7 @@ background = "secondary"
 #title = ""
 #subtitle = ""
 
-[[logos]]
+[[assets]]
   text = "syna"
   weight = 10
   image = "syna.svg"

--- a/exampleSite/content/fragments/member/members/donald.md
+++ b/exampleSite/content/fragments/member/members/donald.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 4"
 weight = 30
 date = "2017-10-17"
 
-image = "tinygopher.png"
+[asset]
+  image = "tinygopher.png"
+
 position = "Gopherineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 scope = [

--- a/exampleSite/content/fragments/member/members/ella.md
+++ b/exampleSite/content/fragments/member/members/ella.md
@@ -3,7 +3,9 @@ title = "Huge Gopher"
 weight = 0
 date = "2017-10-17"
 
-image = "hugegopher.png"
+[asset]
+  image = "hugegopher.png"
+
 position = "Lead Gopherineer"
 reports_to = "CTO"
 lives_in = "[Munich, Germany](https://www.google.com/maps/place/Munich,+Germany/)"

--- a/exampleSite/content/fragments/member/members/gopher.md
+++ b/exampleSite/content/fragments/member/members/gopher.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher"
 weight = 10
 date = "2017-10-17"
 
-image = "tinygopher.png"
+[asset]
+  image = "tinygopher.png"
+
 position = "Gopherineer"
 reports_to = "Lead Gophineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"

--- a/exampleSite/content/fragments/member/members/hector.md
+++ b/exampleSite/content/fragments/member/members/hector.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 5"
 weight = 30
 date = "2017-10-17"
 
-image = "tinygopher.png"
+[asset]
+  image = "tinygopher.png"
+
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"
 
 [[icons]]

--- a/exampleSite/content/fragments/member/members/nancy.md
+++ b/exampleSite/content/fragments/member/members/nancy.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 2"
 weight = 20
 date = "2017-10-17"
 
-image = "tinygopher.png"
+[asset]
+  image = "tinygopher.png"
+
 position = "Gopherineer"
 reports_to = "Lead Gophineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"

--- a/exampleSite/content/fragments/member/members/yoda.md
+++ b/exampleSite/content/fragments/member/members/yoda.md
@@ -3,7 +3,9 @@ title = "Tiny Gopher 3"
 weight = 30
 date = "2017-10-17"
 
-image = "tinygopher.png"
+[asset]
+  image = "tinygopher.png"
+
 position = "Gopherineer"
 reports_to = "Lead Gophineer"
 lives_in = "[Iceland](https://www.google.com/maps/place/Iceland/)"

--- a/exampleSite/content/fragments/member/single-member/bio.md
+++ b/exampleSite/content/fragments/member/single-member/bio.md
@@ -2,7 +2,10 @@
   title = "Huge Gopher"
   weight = 0
   date = "2017-10-17"
-  image = "hugegopher.png"
+  
+  [asset]
+    image = "hugegopher.png"
+
   position = "Lead Gopherineer"
   company = "Okkur Labs"
 

--- a/exampleSite/content/fragments/nav/code-nav-example.md
+++ b/exampleSite/content/fragments/nav/code-nav-example.md
@@ -13,7 +13,7 @@ weight = 110
 background = "secondary"
 
 # Branding options
-[branding]
+[asset]
   image = "logo.svg"
   text = "Syna"
 

--- a/exampleSite/content/fragments/nav/nav-example.md
+++ b/exampleSite/content/fragments/nav/nav-example.md
@@ -6,7 +6,7 @@ weight = 110
 background = "secondary"
 
 # Branding options
-[branding]
+[asset]
   image = "logo.svg"
   text = "Syna"
 

--- a/exampleSite/content/fragments/portfolio/portfolio/item1.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item1.md
@@ -2,8 +2,10 @@
 weight = 10
 title = "First Title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "cat-1.jpeg"
 url = "#"
+
+[asset]
+  image = "cat-1.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/fragments/portfolio/portfolio/item2.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item2.md
@@ -2,7 +2,9 @@
 weight = 20
 title = "Second Title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "cat-2.jpeg"
+
+[asset]
+  image = "cat-2.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/fragments/portfolio/portfolio/item3.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item3.md
@@ -2,7 +2,9 @@
 weight = 30
 title = "Third Title"
 subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
-image = "dog-1.jpeg"
+
+[asset]
+  image = "dog-1.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/fragments/portfolio/portfolio/item4.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item4.md
@@ -1,6 +1,8 @@
 +++
 weight = 40
-image = "dog-2.jpeg"
+
+[asset]
+  image = "dog-2.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/fragments/portfolio/portfolio/item5.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item5.md
@@ -1,6 +1,8 @@
 +++
 weight = 50
-image = "dog-3.jpeg"
+
+[asset]
+  image = "dog-3.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/exampleSite/content/fragments/portfolio/portfolio/item6.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/item6.md
@@ -1,6 +1,8 @@
 +++
 weight = 60
-image = "bird-1.jpeg"
+
+[asset]
+  image = "bird-1.jpeg"
 +++
 
 Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.

--- a/layouts/partials/fragments/404.html
+++ b/layouts/partials/fragments/404.html
@@ -3,30 +3,8 @@
 {{ "<!-- 404 -->" | safeHTML }}
 <section>
   <div class="jumbotron text-center mb-0">
-    {{- with (.Params.logo | default (dict "image" "logo.svg")) -}}
-      {{/* Global resource fallback - can also be used within loops */}}
-      {{- $image := .image -}}
-
-      {{/* Do not change the following snippet */}}
-      {{/* Code is duplicated throughout the code */}}
-      {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-      {{/* Page specific resource */}}
-      {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-      {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $location := strings.TrimPrefix "_index/" $location -}}
-      {{- $.root.Scratch.Set "image" $location -}}
-      {{- end -}}
-
-      {{/* Fragment specific resource */}}
-      {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-      {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $location := strings.TrimPrefix "_index/" $location -}}
-      {{- $.root.Scratch.Set "image" $location -}}
-      {{- end -}}
-      {{/* End of do not change */}}
-      <img class="img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ $self.Site.Title }}"
+    {{- with (.Params.asset | default (dict "image" "logo.svg")) -}}
+      <img class="img-fluid" src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" alt="{{ $self.Site.Title }}"
         {{- if .height -}} height="{{ .height }}"{{- end -}}
         {{- if .width -}} width="{{ .width }}"{{- end -}}
       ></img>

--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -1,28 +1,5 @@
+{{- $self := . -}}
 {{- $bg := .Params.background | default "dark" }}
-
-{{/* Global resource fallback - can also be used within loops */}}
-{{- $image := .Params.logo.image -}}
-
-{{/* Do not change the following snippet */}}
-{{/* Code is duplicated throughout the code */}}
-{{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-{{/* Page specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-
-{{/* Fragment specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-{{/* End of do not change */}}
 
 {{ "<!-- Footer -->" | safeHTML }}
 <div class="overlay container-fluid
@@ -37,13 +14,13 @@
           {{- printf " text-%s" "secondary" -}}
         {{- end -}}
       ">
-        {{- with .Params.logo }}
+        {{- with .Params.asset }}
           <h4>
             {{- .title -}}
           </h4>
           {{- if .image }}
           <a href="{{ .url }}">
-            <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid w-50" alt="{{ .text }}">
+            <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" class="img-fluid w-50" alt="{{ .text }}">
           </a>
           {{- else }}
           <div>

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -22,7 +22,7 @@
   {{- if .Params.asset -}}
     {{- with .Params.asset }}
       <div class="row justify-content-center align-items-start">
-        <img class="overlay img-fluid" src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" alt="{{ $self.Params.title }}"
+        <img class="overlay img-fluid" src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" alt="{{ .title }}"
           {{- if .height -}} height="{{ .height }}"{{- end -}}
           {{- if .width -}} width="{{ .width }}"{{- end -}}
         ></img>

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -1,6 +1,7 @@
 {{- $bg := .Params.background | default "secondary" -}}
-{{- if .Params.particles }}
-  {{- .page_scratch.Add "js" ("syna-hero.js" | relURL) }}
+{{- $self := . -}}
+{{- if .Params.particles -}}
+  {{- .page_scratch.Add "js" ("syna-hero.js" | relURL) -}}
 {{- end }}
 
 {{ "<!-- hero -->" | safeHTML }}
@@ -62,7 +63,7 @@
     {{/* End of do not change */}}
     {{- with .Params.logo }}
       <div class="row justify-content-center align-items-start">
-        <img class="overlay img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}"
+        <img class="overlay img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ $self.Params.title }}"
           {{- if .height -}} height="{{ .height }}"{{- end -}}
           {{- if .width -}} width="{{ .width }}"{{- end -}}
         ></img>

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -7,27 +7,7 @@
 {{ "<!-- hero -->" | safeHTML }}
 <header id="{{ .Name }}">
   {{- if .Params.header }}
-    {{/* Global resource fallback - can also be used within loops */}}
-    {{- $image := .Params.header -}}
-
-    {{/* Do not change the following snippet */}}
-    {{/* Code is duplicated throughout the code */}}
-    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-    {{/* Page specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $.root.Scratch.Set "image" $location -}}
-    {{- end -}}
-
-    {{/* Fragment specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $.root.Scratch.Set "image" $location -}}
-    {{- end -}}
-    {{/* End of do not change */}}
-    <div style="background-image:url({{ $.root.Scratch.Get "image" | relURL }})"
+    <div style="background-image:url({{ partial "helpers/image.html" (dict "root" $self "asset" .Params.header) }})"
       class="jumbotron text-center header-image mb-0
       {{- printf " bg-%s" $bg -}}
     ">
@@ -39,31 +19,10 @@
   {{- if .Params.particles }}
     <div id="particles-js"></div>
   {{- end -}}
-  {{- if .Params.logo -}}
-    {{/* Global resource fallback - can also be used within loops */}}
-    {{- $image := .Params.logo.image -}}
-
-    {{/* Do not change the following snippet */}}
-    {{/* Code is duplicated throughout the code */}}
-    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-    {{/* Page specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $.root.Scratch.Set "image" $location -}}
-    {{- end -}}
-
-    {{/* Fragment specific resource */}}
-    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-    {{- if (fileExists (printf "content/%s" $location)) -}}
-      {{/* special case index: trim _index/ from url */}}
-      {{- $.root.Scratch.Set "image" $location -}}
-    {{- end -}}
-    {{/* End of do not change */}}
-    {{- with .Params.logo }}
+  {{- if .Params.asset -}}
+    {{- with .Params.asset }}
       <div class="row justify-content-center align-items-start">
-        <img class="overlay img-fluid" src="{{ $.root.Scratch.Get "image" | relURL }}" alt="{{ $self.Params.title }}"
+        <img class="overlay img-fluid" src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" alt="{{ $self.Params.title }}"
           {{- if .height -}} height="{{ .height }}"{{- end -}}
           {{- if .width -}} width="{{ .width }}"{{- end -}}
         ></img>

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -97,7 +97,7 @@
                     <i class="{{ .Params.icon }} fa-stack-1x fa-inverse"></i>
                   </span>
                 {{- else if .Params.asset -}}
-                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.title }}">
+                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.title }}">
                 {{- end -}}
                 {{- if and (not .Params.icon) (not .Params.asset) -}}
                   {{- range .Params.buttons }}
@@ -281,7 +281,7 @@
               </div>
             {{- else if .Params.asset }}
               <div class="col-12 text-center d-none d-lg-inline">
-                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.title }}">
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.title }}">
               </div>
             {{- end -}}
             {{- if and (not .Params.icon) (not .Params.asset) }}

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -97,7 +97,7 @@
                     <i class="{{ .Params.icon }} fa-stack-1x fa-inverse"></i>
                   </span>
                 {{- else if .Params.asset -}}
-                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.title }}">
+                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.text }}">
                 {{- end -}}
                 {{- if and (not .Params.icon) (not .Params.asset) -}}
                   {{- range .Params.buttons }}
@@ -281,7 +281,7 @@
               </div>
             {{- else if .Params.asset }}
               <div class="col-12 text-center d-none d-lg-inline">
-                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.title }}">
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.asset.text }}">
               </div>
             {{- end -}}
             {{- if and (not .Params.icon) (not .Params.asset) }}

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -1,29 +1,6 @@
+{{- $self := . -}}
 {{- $bg := .Params.background | default "light" -}}
-{{- $align := .Params.align | default "center" -}}
-
-{{/* Global resource fallback - can also be used within loops */}}
-{{- $image := .Params.image -}}
-
-{{/* Do not change the following snippet */}}
-{{/* Code is duplicated throughout the code */}}
-{{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-{{/* Page specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-
-{{/* Fragment specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-{{/* End of do not change */}}
+{{- $align := .Params.align | default "center" }}
 
 {{ "<!-- Item -->" | safeHTML }}
 <section id="{{ .Name }}">
@@ -87,7 +64,7 @@
             {{- else -}}
               {{- printf " order-lg-12" -}}
             {{- end -}}
-            {{- if and (not .Params.icon) (not .Params.image) -}}
+            {{- if and (not .Params.icon) (not .Params.asset) -}}
               {{- printf " " -}}
             {{- end -}}
           ">
@@ -119,10 +96,10 @@
                     "></i>
                     <i class="{{ .Params.icon }} fa-stack-1x fa-inverse"></i>
                   </span>
-                {{- else if .Params.image -}}
-                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid p-2" alt="{{ .Params.title }}">
+                {{- else if .Params.asset -}}
+                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.title }}">
                 {{- end -}}
-                {{- if and (not .Params.icon) (not .Params.image) -}}
+                {{- if and (not .Params.icon) (not .Params.asset) -}}
                   {{- range .Params.buttons }}
                     <a class="btn btn-lg m-2 d-none d-lg-inline
                       {{ if hasPrefix .url "#" }} anchor{{ end }}
@@ -174,7 +151,7 @@
             </div>
           </div>
           {{- end -}}
-          {{- if or .Params.icon .Params.image }}
+          {{- if or .Params.icon .Params.asset }}
             <div class="col-12 text-center mb-2 {{ printf "text-lg-%s" $align }}">
               {{- range .Params.buttons }}
                 <a class="btn btn-lg m-2
@@ -302,12 +279,12 @@
                   <i class="{{ .Params.icon }} fa-stack-1x fa-inverse"></i>
                 </span>
               </div>
-            {{- else if .Params.image }}
+            {{- else if .Params.asset }}
               <div class="col-12 text-center d-none d-lg-inline">
-                <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid p-2" alt="{{ .Params.title }}">
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid p-2" alt="{{ .Params.title }}">
               </div>
             {{- end -}}
-            {{- if and (not .Params.icon) (not .Params.image) }}
+            {{- if and (not .Params.icon) (not .Params.asset) }}
               <div class="col-12 text-center">
                 {{- range .Params.buttons }}
                   <a class="btn btn-lg m-2

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -63,12 +63,18 @@
           {{/* End of do not change */}}
 
           <div class="col-7 col-sm-4 text-center py-2">
-            {{- if .url }}
-              <a href="{{ .url }}">
+            {{- if .image -}}
+              {{- if .url }}
+                <a href="{{ .url }}">
+                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
+                </a>
+              {{- else }}
                 <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
-              </a>
+              {{- end }}
             {{- else }}
-              <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
+              <div class="col-12 mb-0 d-none d-lg-inline text-muted text-secondary">
+                <p class="mb-0">{{ .text }}</p>
+              </div>
             {{- end }}
           </div>
         {{- end }}

--- a/layouts/partials/fragments/logos.html
+++ b/layouts/partials/fragments/logos.html
@@ -1,3 +1,4 @@
+{{- $self := . -}}
 {{- $bg := .Params.background | default "white" }}
 
 {{ "<!-- Logos -->" | safeHTML }}
@@ -37,39 +38,15 @@
         </div>
       {{- end }}
       <div class="row justify-content-center align-items-center">
-        {{- range sort .Params.logos "weight" }}
-          {{/* Global resource fallback - can also be used within loops */}}
-          {{- $image := .image -}}
-
-          {{/* Do not change the following snippet */}}
-          {{/* Code is duplicated throughout the code */}}
-          {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-          {{/* Page specific resource */}}
-          {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-          {{- if (fileExists (printf "content/%s" $location)) -}}
-            {{/* special case index: trim _index/ from url */}}
-            {{- $location := strings.TrimPrefix "_index/" $location -}}
-            {{- $.root.Scratch.Set "image" $location -}}
-          {{- end -}}
-
-          {{/* Fragment specific resource */}}
-          {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-          {{- if (fileExists (printf "content/%s" $location)) -}}
-            {{/* special case index: trim _index/ from url */}}
-            {{- $location := strings.TrimPrefix "_index/" $location -}}
-            {{- $.root.Scratch.Set "image" $location -}}
-          {{- end -}}
-          {{/* End of do not change */}}
-
+        {{- range sort .Params.assets "weight" }}
           <div class="col-7 col-sm-4 text-center py-2">
             {{- if .image -}}
               {{- if .url }}
                 <a href="{{ .url }}">
-                  <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
+                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" class="p-2 w-75" alt="{{ .text }}">
                 </a>
               {{- else }}
-                <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="p-2 w-75" alt="{{ .text }}">
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}" class="p-2 w-75" alt="{{ .text }}">
               {{- end }}
             {{- else }}
               <div class="col-12 mb-0 d-none d-lg-inline text-muted text-secondary">

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -78,7 +78,7 @@
                       {{- else -}}
                         {{- printf " border-%s" "white" -}}
                       {{- end -}}
-                    " alt=""></img>
+                    " alt="{{ $member.title }}"></img>
                   </div>
                 {{- end -}}
                 <div class="mt-5 mb-0
@@ -192,7 +192,7 @@
                       {{- else -}}
                         {{- printf " border-%s" "white" -}}
                       {{- end -}}
-                    " alt=""></img>
+                    " alt="{{ $member.title }}"></img>
                   </div>
                 {{- end -}}
                 <div class="col-12 text-lg-left

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -1,3 +1,4 @@
+{{- $self := . -}}
 {{- $members := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
 {{- $bg := .Params.background | default "light" }}
 
@@ -48,31 +49,9 @@
             {{- if not (in .Name "/index.md") -}}
               {{- $member := .Params -}}
               <div class="col-lg-4 col-md-6 col-sm-12 pt-3 pb-5 text-left text-sm-center">
-                {{- if .Params.image -}}
-                  {{/* Global resource fallback - can also be used within loops */}}
-                  {{- $image := .Params.image -}}
-    
-                  {{/* Do not change the following snippet */}}
-                  {{/* Code is duplicated throughout the code */}}
-                  {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-                  {{/* Page specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                  {{/* special case index: trim _index/ from url */}}
-                  {{- $location := strings.TrimPrefix "_index/" $location -}}
-                  {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-    
-                  {{/* Fragment specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                  {{/* special case index: trim _index/ from url */}}
-                  {{- $location := strings.TrimPrefix "_index/" $location -}}
-                  {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-                  {{/* End of do not change */}}
+                {{- if .Params.asset -}}
                   <div class="text-center m-2">
-                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle w-75 border
+                    <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid rounded-circle w-75 border
                       {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                         {{- printf " border-%s" "dark" -}}
                       {{- else -}}
@@ -154,39 +133,16 @@
       {{- else if le $members 1 -}}
         <div class="card p-2">
           <div class="row m-0 justify-content-center 
-            {{- if .Params.image -}}
+            {{- if .Params.asset -}}
               {{- printf " align-items-center" -}}
             {{- end -}}">
             {{- range $members -}}
               {{/* Handle special case of index.md being considered a member */}}
               {{- if not (in .Name "/index.md") -}}
                 {{- $member := .Params -}}
-                {{- if .Params.image -}}
-                  {{/* Global resource fallback - can also be used within loops */}}
-                  {{- $image := .Params.image -}}
-
-                  {{/* Do not change the following snippet */}}
-                  {{/* Code is duplicated throughout the code */}}
-                  {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-                  {{/* Page specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                  {{/* special case index: trim _index/ from url */}}
-                  {{- $location := strings.TrimPrefix "_index/" $location -}}
-                  {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-
-                  {{/* Fragment specific resource */}}
-                  {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                  {{- if (fileExists (printf "content/%s" $location)) -}}
-                  {{/* special case index: trim _index/ from url */}}
-                  {{- $location := strings.TrimPrefix "_index/" $location -}}
-                  {{- $.root.Scratch.Set "image" $location -}}
-                  {{- end -}}
-                  {{/* End of do not change */}}
+                {{- if .Params.asset -}}
                   <div class="col-12 col-lg-4 p-4 text-center">
-                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid rounded-circle border
+                    <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid rounded-circle border
                       {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                         {{- printf " border-%s" "dark" -}}
                       {{- else -}}
@@ -196,7 +152,7 @@
                   </div>
                 {{- end -}}
                 <div class="col-12 text-lg-left
-                  {{- if .Params.image -}}
+                  {{- if .Params.asset -}}
                     {{- printf " col-lg-8 pb-4 pt-0 pl-lg-5 pt-lg-4 text-center" -}}
                   {{- else -}}
                     {{- printf " col-lg-4" -}}
@@ -264,7 +220,7 @@
                 </div>
                 {{- if .Content -}}
                   <div class="col-12 text-center text-lg-left
-                    {{- if .Params.image -}}
+                    {{- if .Params.asset -}}
                       {{- printf " p-4" -}}
                     {{- else -}}
                       {{- printf " col-lg-8 pt-0 pl-lg-5 text-center" -}}

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -1,28 +1,5 @@
+{{- $self := . -}}
 {{- $bg := .Params.background | default "dark" }}
-
-{{/* Global resource fallback - can also be used within loops */}}
-{{- $image := .Params.branding.image -}}
-
-{{/* Do not change the following snippet */}}
-{{/* Code is duplicated throughout the code */}}
-{{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-
-{{/* Page specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-
-{{/* Fragment specific resource */}}
-{{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-{{- if (fileExists (printf "content/%s" $location)) -}}
-  {{/* special case index: trim _index/ from url */}}
-  {{- $location := strings.TrimPrefix "_index/" $location -}}
-  {{- $.root.Scratch.Set "image" $location -}}
-{{- end -}}
-{{/* End of do not change */}}
 
 {{- "<!-- Navigation -->" | safeHTML -}}
 <nav class="overlay navbar navbar-expand-lg py-2
@@ -34,9 +11,9 @@
   {{- end -}}
 " id="{{ .Name }}">
   <div class="container">
-    {{- if .Params.branding.image }}
+    {{- if .Params.asset.image }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">
-        <img src="{{ $.root.Scratch.Get "image" | relURL }}" height="35" class="d-inline-block align-top" alt="{{ .Params.branding.text }}">
+        <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" height="35" class="d-inline-block align-top" alt="{{ .Params.branding.text }}">
       </a>
     {{- else }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -13,11 +13,11 @@
   <div class="container">
     {{- if .Params.asset.image }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">
-        <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" height="35" class="d-inline-block align-top" alt="{{ .Params.branding.text }}">
+        <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" height="35" class="d-inline-block align-top" alt="{{ .Params.asset.text }}">
       </a>
     {{- else }}
       <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">
-        {{- .Params.branding.text -}}
+        {{- .Params.asset.text -}}
       </a>
     {{- end }}
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -1,3 +1,4 @@
+{{- $self := . -}}
 {{- $items := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
 {{- $bg := .Params.background | default "light" -}}
 {{- .page_scratch.Add "js" ("syna-portfolio.js" | relURL) }}
@@ -54,31 +55,8 @@
                 {{- if .Params.url }}
                   <a href="{{ .Params.url | relURL }}">
                 {{- end }}
-                    {{- if .Params.image -}}
-                      {{/* Global resource fallback - can also be used within loops */}}
-                      {{- $image := .Params.image -}}
-            
-                      {{/* Do not change the following snippet */}}
-                      {{/* Code is duplicated throughout the code */}}
-                      {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-            
-                      {{/* Page specific resource */}}
-                      {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                      {{- if (fileExists (printf "content/%s" $location)) -}}
-                        {{/* special case index: trim _index/ from url */}}
-                        {{- $location := strings.TrimPrefix "_index/" $location -}}
-                        {{- $.root.Scratch.Set "image" $location -}}
-                      {{- end -}}
-            
-                      {{/* Fragment specific resource */}}
-                      {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                      {{- if (fileExists (printf "content/%s" $location)) -}}
-                        {{/* special case index: trim _index/ from url */}}
-                        {{- $location := strings.TrimPrefix "_index/" $location -}}
-                        {{- $.root.Scratch.Set "image" $location -}}
-                      {{- end -}}
-                      {{/* End of do not change */}}
-                      <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid" alt="{{ .Params.title }}">
+                    {{- if .Params.asset -}}
+                      <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid" alt="{{ .Params.title }}">
                     {{- end }}
                     <div class="position-absolute hover-overlay"></div>
                     {{- if or .Params.title .Params.subtitle }}

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -56,7 +56,7 @@
                   <a href="{{ .Params.url | relURL }}">
                 {{- end }}
                     {{- if .Params.asset -}}
-                      <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid" alt="{{ .Params.asset.title }}">
+                      <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid" alt="{{ .Params.asset.text }}">
                     {{- end }}
                     <div class="position-absolute hover-overlay"></div>
                     {{- if or .Params.title .Params.subtitle }}

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -54,30 +54,32 @@
                 {{- if .Params.url }}
                   <a href="{{ .Params.url | relURL }}">
                 {{- end }}
-                    {{/* Global resource fallback - can also be used within loops */}}
-                    {{- $image := .Params.image -}}
-          
-                    {{/* Do not change the following snippet */}}
-                    {{/* Code is duplicated throughout the code */}}
-                    {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
-          
-                    {{/* Page specific resource */}}
-                    {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
-                    {{- if (fileExists (printf "content/%s" $location)) -}}
-                      {{/* special case index: trim _index/ from url */}}
-                      {{- $location := strings.TrimPrefix "_index/" $location -}}
-                      {{- $.root.Scratch.Set "image" $location -}}
-                    {{- end -}}
-          
-                    {{/* Fragment specific resource */}}
-                    {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
-                    {{- if (fileExists (printf "content/%s" $location)) -}}
-                      {{/* special case index: trim _index/ from url */}}
-                      {{- $location := strings.TrimPrefix "_index/" $location -}}
-                      {{- $.root.Scratch.Set "image" $location -}}
-                    {{- end -}}
-                    {{/* End of do not change */}}
-                    <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid" alt="{{ .Params.title }}">
+                    {{- if .Params.image -}}
+                      {{/* Global resource fallback - can also be used within loops */}}
+                      {{- $image := .Params.image -}}
+            
+                      {{/* Do not change the following snippet */}}
+                      {{/* Code is duplicated throughout the code */}}
+                      {{- $.root.Scratch.Set "image" (printf "images/%s" $image) -}}
+            
+                      {{/* Page specific resource */}}
+                      {{- $location := (printf "%s/%s" $.fallthrough.page_path $image) -}}
+                      {{- if (fileExists (printf "content/%s" $location)) -}}
+                        {{/* special case index: trim _index/ from url */}}
+                        {{- $location := strings.TrimPrefix "_index/" $location -}}
+                        {{- $.root.Scratch.Set "image" $location -}}
+                      {{- end -}}
+            
+                      {{/* Fragment specific resource */}}
+                      {{- $location := (printf "%s/%s" $.fallthrough.file_path $image) -}}
+                      {{- if (fileExists (printf "content/%s" $location)) -}}
+                        {{/* special case index: trim _index/ from url */}}
+                        {{- $location := strings.TrimPrefix "_index/" $location -}}
+                        {{- $.root.Scratch.Set "image" $location -}}
+                      {{- end -}}
+                      {{/* End of do not change */}}
+                      <img src="{{ $.root.Scratch.Get "image" | relURL }}" class="img-fluid" alt="{{ .Params.title }}">
+                    {{- end }}
                     <div class="position-absolute hover-overlay"></div>
                     {{- if or .Params.title .Params.subtitle }}
                       <div class="position-absolute description-container col">

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -56,7 +56,7 @@
                   <a href="{{ .Params.url | relURL }}">
                 {{- end }}
                     {{- if .Params.asset -}}
-                      <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid" alt="{{ .Params.title }}">
+                      <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" class="img-fluid" alt="{{ .Params.asset.title }}">
                     {{- end }}
                     <div class="position-absolute hover-overlay"></div>
                     {{- if or .Params.title .Params.subtitle }}

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -1,0 +1,20 @@
+{{/* Global resource fallback */}}
+{{- $image := .asset.image -}}
+
+{{/* Code is duplicated throughout the code */}}
+{{- .root.page_scratch.Set "image" (printf "images/%s" $image) -}}
+{{/* Page specific resource */}}
+{{- $location := (printf "%s/%s" .root.page_path $image) -}}
+{{- if (fileExists (printf "content/%s" $location)) -}}
+  {{/* special case index: trim _index/ from url */}}
+  {{- .root.page_scratch.Set "image" $location -}}
+{{- end -}}
+
+{{/* Fragment specific resource */}}
+{{- $location := (printf "%s/%s" .root.file_path $image) -}}
+{{- if (fileExists (printf "content/%s" $location)) -}}
+  {{/* special case index: trim _index/ from url */}}
+  {{- .root.page_scratch.Set "image" $location -}}
+{{- end -}}
+
+{{- .root.page_scratch.Get "image" | relURL -}}

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -1,17 +1,16 @@
 {{/* Global resource fallback */}}
 {{- $image := .asset.image -}}
-
-{{/* Code is duplicated throughout the code */}}
 {{- .root.page_scratch.Set "image" (printf "images/%s" $image) -}}
+
 {{/* Page specific resource */}}
-{{- $location := (printf "%s/%s" .root.page_path $image) -}}
+{{- $location := (printf "%s/%s" .root.fallthrough.page_path $image) -}}
 {{- if (fileExists (printf "content/%s" $location)) -}}
   {{/* special case index: trim _index/ from url */}}
   {{- .root.page_scratch.Set "image" $location -}}
 {{- end -}}
 
 {{/* Fragment specific resource */}}
-{{- $location := (printf "%s/%s" .root.file_path $image) -}}
+{{- $location := (printf "%s/%s" .root.fallthrough.file_path $image) -}}
 {{- if (fileExists (printf "content/%s" $location)) -}}
   {{/* special case index: trim _index/ from url */}}
   {{- .root.page_scratch.Set "image" $location -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Create a new helper called `image` which returns a string for the relative url of an image.

Image declaration for fragments has changed to the following:

```
[asset]
  image = "image-path"
  ... other variables
```

In places where there are several images of the same type (logos for now) I used `assets` and for places with more than one type of image I use one `asset` and the name for the other type (hero is the only fragment with this complexity and there is `header` and `asset`).

I haven't done the same with icons for now since the diff is too long and didn't want more complexity to come in. If possible, I'll do icons in another PR.

Also will add the documentation after the review so we wouldn't need to redo it in case of any changes to the structure.

**Which issue this PR fixes**:
fixes #305 

**Release note**:
```release-note
BREAKING: Image declaration has changed for fragments
```
