### PR TITLE
Fix list fragment content check and add list page for dev section

### DIFF
--- a/exampleSite/content/dev/_index.md
+++ b/exampleSite/content/dev/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Dev section"
++++

--- a/exampleSite/content/dev/_index/index.md
+++ b/exampleSite/content/dev/_index/index.md
@@ -1,0 +1,3 @@
++++
+headless = true
++++

--- a/exampleSite/content/dev/_index/index.md
+++ b/exampleSite/content/dev/_index/index.md
@@ -1,3 +1,9 @@
 +++
 headless = true
+fragment = "content"
+weight = 90
+title = "Dev Section"
 +++
+
+These are the testing pages we use to make sure everything works as planned and
+nothing breaks during iterations.

--- a/exampleSite/content/dev/_index/list.md
+++ b/exampleSite/content/dev/_index/list.md
@@ -1,0 +1,4 @@
++++
+fragment = "list"
+weight = 100
++++

--- a/exampleSite/content/dev/_index/list.md
+++ b/exampleSite/content/dev/_index/list.md
@@ -1,7 +1,4 @@
 +++
 fragment = "list"
 weight = 100
-
-#subsections = true # Default to true. Shows subsection branch pages
-#subsection_leaves = true # Default to false. Shows subsection leaf pages
 +++

--- a/exampleSite/content/dev/_index/list.md
+++ b/exampleSite/content/dev/_index/list.md
@@ -1,4 +1,7 @@
 +++
 fragment = "list"
 weight = 100
+
+#subsections = true # Default to true. Shows subsection branch pages
+#subsection_leaves = true # Default to false. Shows subsection leaf pages
 +++

--- a/exampleSite/content/dev/empty-subitems/index.md
+++ b/exampleSite/content/dev/empty-subitems/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Emtpy subitems"
+title = "Empty subitems"
 date = "2017-09-07"
 description = "Test notice for subpath items not being configured"
 

--- a/exampleSite/content/dev/empty-subitems/index.md
+++ b/exampleSite/content/dev/empty-subitems/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Emtpy subitems"
 date = "2017-09-07"
 description = "Test notice for subpath items not being configured"
+
+weight = 10
 +++

--- a/exampleSite/content/dev/missing-images/index.md
+++ b/exampleSite/content/dev/missing-images/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Missing images"
 date = "2017-09-07"
 description = "Demo missing or loading issues for images"
+
+weight = 20
 +++

--- a/exampleSite/content/dev/resource-fallthrough/_index.md
+++ b/exampleSite/content/dev/resource-fallthrough/_index.md
@@ -1,0 +1,3 @@
++++
+title = "Resource fallthrough"
++++

--- a/exampleSite/content/dev/resource-fallthrough/_index/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/_index/index.md
@@ -1,0 +1,3 @@
++++
+headless = true
++++

--- a/exampleSite/content/dev/resource-fallthrough/_index/list.md
+++ b/exampleSite/content/dev/resource-fallthrough/_index/list.md
@@ -1,0 +1,3 @@
++++
+fragment = "list"
++++

--- a/exampleSite/content/dev/resource-fallthrough/fragment/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Resource fallthrough - Fragment"
 date = "2017-09-07"
 description = "Dev demo for fragment level resource fallthrough"
+
+weight = 100
 +++

--- a/exampleSite/content/dev/resource-fallthrough/fragment/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/fragment/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Resource fallthrough - Fragment"
+title = "Fragment"
 date = "2017-09-07"
 description = "Dev demo for fragment level resource fallthrough"
 

--- a/exampleSite/content/dev/resource-fallthrough/global/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Resource fallthrough - Global"
+title = "Global"
 date = "2017-09-07"
 description = "Dev demo for global resource fallthrough"
 

--- a/exampleSite/content/dev/resource-fallthrough/global/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/global/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Resource fallthrough - Global"
 date = "2017-09-07"
 description = "Dev demo for global resource fallthrough"
+
+weight = 120
 +++

--- a/exampleSite/content/dev/resource-fallthrough/page/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Resource fallthrough - Page"
+title = "Page"
 date = "2017-09-07"
 description = "Dev demo for page level resource fallthrough"
 

--- a/exampleSite/content/dev/resource-fallthrough/page/index.md
+++ b/exampleSite/content/dev/resource-fallthrough/page/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Resource fallthrough - Page"
 date = "2017-09-07"
 description = "Dev demo for page level resource fallthrough"
+
+weight = 110
 +++

--- a/exampleSite/content/dev/unconfigured-images/index.md
+++ b/exampleSite/content/dev/unconfigured-images/index.md
@@ -1,5 +1,7 @@
 +++
-title = "Syna Theme"
+title = "Unconfigured images"
 date = "2017-09-07"
 description = "Demo missing or loading issues for images"
+
+weight = 30
 +++

--- a/exampleSite/content/fragments/_index/list.md
+++ b/exampleSite/content/fragments/_index/list.md
@@ -6,4 +6,7 @@ weight = 150
 count = 1000
 section = "fragments"
 #summary = false # Default value is true
+
+#subsections = true # Default to true. Shows subsection branch pages
+#subsection_leaves = true # Default to false. Shows subsection leaf pages
 +++

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -7,7 +7,6 @@
 {{- if and (not .Params.section) (eq .root.CurrentSection.Kind "section") -}}
   {{- .page_scratch.Set "pages" (.root.CurrentSection.Pages) -}}
 {{- end -}}
-{{- $pages := where (.page_scratch.Get "pages") "Params.fragment" "eq" "content" -}}
 {{- $self := . -}}
 {{- $bg := .Params.background | default "light" }}
 
@@ -23,7 +22,7 @@
             {{- printf " text-muted text-%s" "secondary" -}}
           {{- end -}}
         ">
-          {{- range first (.Params.count | default 10) $pages }}
+          {{- range first (.Params.count | default 10) (.page_scratch.Get "pages") }}
             <article class="col-12 mb-4">
               {{- if .Params.title }}
                 <div class="col-12 pl-0

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -1,13 +1,22 @@
+{{- $self := . -}}
 {{/*
   This variable stores all the page bundles in the blog section. There are three
   where functions achieving this. First where gets all the pages in blog
   section, the second one removes current page from the mix and the last one
   removes the section (.Site.Pages returns the current section as a page). */}}
-{{- .page_scratch.Set "pages" (where .Site.Pages.ByDate "Section" (.Params.section | default .root.Section)) -}}
+{{- .page_scratch.Set "pages" (.Site.GetPage "Section" (.Params.section | default .root.Section)).Pages -}}
+{{- .page_scratch.Add "pages" (.Site.GetPage "Section" (.Params.section | default .root.Section)).Sections -}}
 {{- if and (not .Params.section) (eq .root.CurrentSection.Kind "section") -}}
   {{- .page_scratch.Set "pages" (.root.CurrentSection.Pages) -}}
+  {{- if (ne .Params.subsections false) -}}
+    {{- .page_scratch.Add "pages" .root.CurrentSection.Sections -}}
+  {{- end -}}
+  {{- if .Params.subsection_leaves -}}
+    {{- range .root.CurrentSection.Sections -}}
+      {{- $self.page_scratch.Add "pages" .Pages -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
-{{- $self := . -}}
 {{- $bg := .Params.background | default "light" }}
 
 {{ "<!-- Blog -->" | safeHTML }}

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -16,7 +16,7 @@
   */}}
 {{- $local_fragments := $real_page.Resources.ByType "page" -}}
 
-{{- $page_scratch.Set "fragments" (slice $real_page) -}}
+{{- $page_scratch.Set "fragments" (slice $page) -}}
 {{- $page_scratch.Set "local_fragments_dirs" (slice) -}}
 {{- range $local_fragments -}}
   {{- $page_scratch.Add "fragments" (slice .) -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
- List section had a check for the pages to see if the page's index file was a content fragment. This prevented listing pages with no content fragment or pages in which index was not a fragment or a different one.
- Added list page to the dev section

**Release note**:
```release-note
list: Removed the check for the pages to ensure pages where content fragments
```
