### PR TITLE
Extract title and subtitle to a helper where possible

### DIFF
--- a/layouts/partials/fragments/buttons.html
+++ b/layouts/partials/fragments/buttons.html
@@ -6,36 +6,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-4">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "secondary") (eq $bg "white") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "white" -}}
-            {{- end -}}
-          ">
-            <h4>
-              {{- . | markdownify -}}
-            </h4>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row text-center justify-content-center">
         {{- range .Params.buttons }}
           <a class="btn btn-lg m-2{{ if hasPrefix .url "#" }} anchor{{ end }}

--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -11,30 +11,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
   <div class="container py-5">
-    <div class="row">
-      <div class="col-12 text-center
-        {{- if eq $bg "dark" -}}
-          {{- printf " text-%s" "light" -}}
-        {{- else -}}
-          {{- printf " text-%s" "dark" -}}
-        {{- end -}}
-      ">
-        {{- with .Params.title }}
-          <h2>{{- . | markdownify -}}</h2>
-        {{- end -}}
-        {{- with .Params.subtitle }}
-          <h3 class="
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            {{- . | markdownify }}
-          </h3>
-        {{- end }}
-      </div>
-    </div>
+    {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
     <div class="row">
       <div class="col-12">
         <form

--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -37,32 +37,7 @@
         {{- else }}
           <article class="col-md-12">
         {{- end }}
-          {{- if .Params.title }}
-            <div class="col-12 pb-3
-              {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-                {{- printf " text-%s" "dark" -}}
-              {{- else -}}
-                {{- printf " text-%s" "light" -}}
-              {{- end -}}
-            ">
-              <h1>
-                {{- .Params.title | markdownify -}}
-              </h1>
-            </div>
-          {{- end -}}
-          {{- if .Params.subtitle }}
-            <div class="col-12 pb-2
-              {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-                {{- printf " text-%s" "dark" -}}
-              {{- else -}}
-                {{- printf " text-muted text-%s" "secondary" -}}
-              {{- end -}}
-            ">
-              <h3>
-                {{- .Params.subtitle | markdownify -}}
-              </h3>
-            </div>
-          {{- end }}
+          {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
           {{- if or .Params.display_date .Params.categories -}}
             <div class="col-12 pb-4 mt-2">
               {{- if .Params.display_date -}}

--- a/layouts/partials/fragments/embed.html
+++ b/layouts/partials/fragments/embed.html
@@ -8,36 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center py-3
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle }}
-        <div class="row">
-          <div class="col text-center pb-4
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row justify-content-center">
         {{- if eq .Params.responsive false }}
           <div class="{{- printf "w-%s" $size -}}">

--- a/layouts/partials/fragments/header.html
+++ b/layouts/partials/fragments/header.html
@@ -8,38 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-3">
-      {{- with .Params.title }}
-        <div class="row mx-0">
-          <div class="col
-            {{- printf " text-%s" $align -}}
-            {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "light" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle -}}
-        <div class="row mx-0">
-          <div class="col pt-4 pb-0
-            {{- printf " text-%s" $subtitle_align -}}
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
     </div>
   </div>
 </section>

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -8,36 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "light" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle -}}
-        <div class="row">
-          <div class="col text-center pt-4 pb-5
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row justify-content-center align-items-stretch items">
         {{- if eq (len $items) 0 -}}
           {{- partial "helpers/empty-subpath.html" (dict "context" "items" "root" $) -}}

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -31,6 +31,7 @@
 <section id="{{ .Name }}">
   <div class="overlay container-fluid {{- printf " bg-%s" $bg -}}">
     <div class="container py-5">
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row mx-0">
         <div class="row mx-0
           {{- if or (eq $bg "secondary") (eq $bg "primary") -}}

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -8,36 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "light" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle }}
-        <div class="row">
-          <div class="col text-center pt-2 pb-3
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{ end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       {{- if eq (len $members) 0 -}}
         {{- partial "helpers/empty-subpath.html" (dict "context" "member" "root" $) -}}
       {{- else if gt $members 1 -}}

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -9,36 +9,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "light" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle -}}
-        <div class="row">
-          <div class="col text-center pt-4 pb-5
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h5>
-              {{- . | markdownify -}}
-            </h5>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row">
         {{- if eq (len $items) 0 }}
           {{- partial "helpers/empty-subpath.html" (dict "context" "portfolio" "root" $) -}}

--- a/layouts/partials/fragments/pricing.html
+++ b/layouts/partials/fragments/pricing.html
@@ -8,39 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
-      {{- with .Params.title }}
-        <div class="row">
-          <div class="col text-center
-            {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-%s" "light" -}}
-            {{- end -}}
-            {{- if and (not (isset $self.Params "subtitle")) (not $self.Content) -}}
-              {{- printf " pb-4" -}}
-            {{- end -}}
-          ">
-            <h2>
-              {{- . | markdownify -}}
-            </h2>
-          </div>
-        </div>
-      {{- end -}}
-      {{- with .Params.subtitle -}}
-        <div class="row">
-          <div class="col text-center pt-2 pb-4
-            {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-              {{- printf " text-%s" "dark" -}}
-            {{- else -}}
-              {{- printf " text-muted text-%s" "secondary" -}}
-            {{- end -}}
-          ">
-            <h6>
-              {{- . | markdownify -}}
-            </h6>
-          </div>
-        </div>
-      {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       {{- with .Content -}}
         <div class="row">
           <div class="col text-center pt-4 pb-5

--- a/layouts/partials/fragments/search.html
+++ b/layouts/partials/fragments/search.html
@@ -8,37 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
   <div class="container py-5">
-    {{- with .Params.title }}
-      <div class="col text-center
-        {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-          {{- printf " text-%s" "dark" -}}
-        {{- else -}}
-          {{- printf " text-%s" "light" -}}
-        {{- end -}}
-        {{- if and (not (isset $self.Params "subtitle")) (not $self.Content) -}}
-          {{- printf " pb-4" -}}
-        {{- end -}}
-      ">
-        <h2>
-          {{- . | markdownify -}}
-        </h2>
-      </div>
-    {{- end -}}
-    {{- with .Params.subtitle -}}
-      <div class="row">
-        <div class="col text-center pt-2 pb-4
-          {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-            {{- printf " text-%s" "dark" -}}
-          {{- else -}}
-            {{- printf " text-muted text-%s" "secondary" -}}
-          {{- end -}}
-        ">
-          <h6>
-            {{- . | markdownify -}}
-          </h6>
-        </div>
-      </div>
-    {{- end }}
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
     <div class="row w-100 justify-content-center mx-0">
       <form action="{{ "search" | absURL }}" class="mt-0">
         <div class="input-group my-0">

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -6,38 +6,9 @@
     {{- printf " bg-%s" $bg -}}
   ">
     <div class="container py-5">
+      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
       <div class="row align-items-center text-center justify-content-end">
         <div class="col-12 order-lg-1 text-center">
-          {{- if .Params.title }}
-            <div class="row pb-3">
-              <div class="col-12
-                {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
-                  {{- printf " text-%s" "dark" -}}
-                {{- else -}}
-                  {{- printf " text-%s" "light" -}}
-                {{- end -}}
-              ">
-                <h2>
-                  {{- .Params.title | markdownify -}}
-                </h2>
-              </div>
-            </div>
-          {{- end -}}
-          {{- if .Params.subtitle }}
-            <div class="row pb-2
-              {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
-                {{- printf " text-%s" "dark" -}}
-              {{- else -}}
-                {{- printf " text-muted text-%s" "secondary" -}}
-              {{- end -}}
-            ">
-              <div class="col-12">
-                <h5>
-                  {{- .Params.subtitle | markdownify -}}
-                </h5>
-              </div>
-            </div>
-          {{- end -}}
           {{- if .Params.rows }}
             <div class="row justify-content-center">
               <div class="col table-responsive">

--- a/layouts/partials/helpers/section-header.html
+++ b/layouts/partials/helpers/section-header.html
@@ -1,0 +1,31 @@
+{{- $bg := .bg -}}
+{{- with .params.title }}
+  <div class="row">
+    <div class="col text-center py-3
+      {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+        {{- printf " text-%s" "dark" -}}
+      {{- else -}}
+        {{- printf " text-%s" "secondary" -}}
+      {{- end -}}
+    ">
+      <h2>
+        {{- . | markdownify -}}
+      </h2>
+    </div>
+  </div>
+{{- end -}}
+{{- with .params.subtitle }}
+  <div class="row">
+    <div class="col text-center pb-4
+      {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+        {{- printf " text-%s" "dark" -}}
+      {{- else -}}
+        {{- printf " text-muted text-%s" "secondary" -}}
+      {{- end -}}
+    ">
+      <h5>
+        {{- . | markdownify -}}
+      </h5>
+    </div>
+  </div>
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Extract title and subtitle from fragments into `section-header` helper, also adds title and subtitle to list fragment (was missing).

**Which issue this PR fixes**:
fixes #365 
