### PR TITLE
Fix random issues with fragments using subpath

### DIFF
--- a/exampleSite/content/dev/empty-subitems/pricing/index.md
+++ b/exampleSite/content/dev/empty-subitems/pricing/index.md
@@ -1,0 +1,6 @@
++++
+fragment = "pricing"
+date = "2017-10-04"
+weight = 400
+title = "pricing"
++++

--- a/exampleSite/content/fragments/items/code-items-no-content.md
+++ b/exampleSite/content/fragments/items/code-items-no-content.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 121
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -14,6 +14,19 @@ background = "secondary"
 
 title = "Items Fragment with no content"
 subtitle= "Column based items with icons"
++++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+
+[asset]
+  icon = "fas fa-random"
+  url = "#"
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-items-only.md
+++ b/exampleSite/content/fragments/items/code-items-only.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 126
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -14,6 +14,19 @@ background = "secondary"
 
 #title = ""
 #subtitle = ""
++++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+
+[asset]
+  icon = "fas fa-random"
+  url = "#"
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-items.md
+++ b/exampleSite/content/fragments/items/code-items.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 111
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -15,5 +15,21 @@ background = "secondary"
 title = "Items Fragment"
 subtitle= "Column based items with icons"
 +++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+title = "Column 1"
+weight = 10
+
+[asset]
+  icon = "fas fa-random"
+  url = "#"
++++
+
+Showcasing descriptions for column based items
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-logos-no-content.md
+++ b/exampleSite/content/fragments/items/code-logos-no-content.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 141
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -14,6 +14,20 @@ background = "secondary"
 
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
++++
+
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+
+[asset]
+  image = "caddy.svg"
+  url = "#"
 +++
 
 ```

--- a/exampleSite/content/fragments/items/code-logos-only.md
+++ b/exampleSite/content/fragments/items/code-logos-only.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 151
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -12,5 +12,19 @@ date = "2017-10-04"
 weight = 150
 background = "secondary"
 +++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+
+[asset]
+  image = "caddy.svg"
+  url = "#"
++++
+
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-logos.md
+++ b/exampleSite/content/fragments/items/code-logos.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 131
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "items"
@@ -15,5 +15,22 @@ background = "secondary"
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
 +++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+title = "Column 1"
+weight = 10
+
+[asset]
+  image = "caddy.svg"
+  url = "#"
++++
+
+Showcasing descriptions for column based items
+
 ```
 </details>

--- a/exampleSite/content/fragments/member/code-members.md
+++ b/exampleSite/content/fragments/member/code-members.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 121
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "member"
@@ -14,5 +14,41 @@ background = "secondary"
 
 title = "Members fragment - Multiple members"
 +++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+title = "Huge Gopher"
+weight = 0
+date = "2017-10-17"
+
+position = "Lead Gopherineer"
+reports_to = "CTO"
+lives_in = "[Munich, Germany](https://www.google.com/maps/place/Munich,+Germany/)"
+scope = [
+  "UX for [Food Dashboard](#)",
+  "Maintainer for [Goper Team A](#)",
+  "Gopher [Community Administration](#)"
+]
+
+[[icons]]
+  icon = "fab fa-linkedin-in"
+  url = "#"
+
+[asset]
+  image = "hugegopher.png"
++++
+
+Hugely huge Gopher
+
+Some more text to showcase the capabilities:
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Curabitur a lorem urna.
+Quisque in neque malesuada, sollicitudin nunc porttitor, ornare est.
+Praesent ante enim, bibendum sed hendrerit et, iaculis laoreet felis.
+Morbi efficitur dui sit amet orci porttitor, nec tincidunt turpis elementum.
 ```
 </details>

--- a/exampleSite/content/fragments/member/code-single-member.md
+++ b/exampleSite/content/fragments/member/code-single-member.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 111
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 fragment = "member"
@@ -15,5 +15,43 @@ background = "secondary"
 title = "Single Member Fragment"
 #subtitle = "Highly motivated Gophers"
 +++
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+title = "Huge Gopher"
+weight = 0
+date = "2017-10-17"
+
+position = "Lead Gopherineer"
+company = "Okkur Labs"
+
+reports_to = "CTO"
+lives_in = "[Munich, Germany](https://www.google.com/maps/place/Munich,+Germany/)"
+scope = [
+  "UX for [Food Dashboard](#)",
+  "Maintainer for [Goper Team A](#)",
+  "Gopher [Community Administration](#)"
+]
+
+[[icons]]
+  icon = "fab fa-linkedin-in"
+  url = "#"
+
+[asset]
+  image = "hugegopher.png"
++++
+
+Hugely huge Gopher
+
+Some more text to showcase the capabilities:
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Curabitur a lorem urna.
+Quisque in neque malesuada, sollicitudin nunc porttitor, ornare est.
+Praesent ante enim, bibendum sed hendrerit et, iaculis laoreet felis.
+Morbi efficitur dui sit amet orci porttitor, nec tincidunt turpis elementum.
 ```
 </details>

--- a/exampleSite/content/fragments/portfolio/code-portfolio.md
+++ b/exampleSite/content/fragments/portfolio/code-portfolio.md
@@ -3,7 +3,7 @@ fragment = "content"
 weight = 111
 +++
 
-<details><summary>Code</summary>
+<details><summary>Code (index)</summary>
 ```
 +++
 date = "2018-07-09"
@@ -16,3 +16,20 @@ subtitle = "Displaying animals with links and modals"
 +++
 ```
 </details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+title = "First Title"
+subtitle = "Lorem ipsum dolor sit amet, consectetur adipiscing"
+url = "#"
+
+[asset]
+  image = "cat-1.jpeg"
++++
+
+Ante in nibh mauris cursus mattis molestie a iaculis. Nisi porta lorem mollis aliquam. Eu consequat ac felis donec et odio pellentesque diam volutpat. Arcu dui vivamus arcu felis. Senectus et netus et malesuada fames ac turpis egestas sed. Orci eu lobortis elementum nibh.
+```
+</div>

--- a/exampleSite/content/fragments/pricing/code-pricing.md
+++ b/exampleSite/content/fragments/pricing/code-pricing.md
@@ -3,7 +3,8 @@ fragment = "content"
 weight = 121
 +++
 
-<details><summary>Code</summary>
+<details>
+<summary>Code (index)</summary>
 ```
 +++
 fragment = "pricing"
@@ -16,5 +17,31 @@ subtitle = "Can be linked to 3rd party payment services"
 
 Pricing fragment supports **markdown** as it's subtitle.  
 Supports feature listing of different plans and links to a payment service.
+```
+</details>
+
+<details>
+<summary>Code (subitem)</summary>
+```
++++
+weight = 10
+
+title = "Starting plan"
+subtitle = "starting at"
+
+price = "Free"
+# highlight = true
+
+button_text = "Start for free"
+button_url = "#"
+
+[[features]]
+  text = "**Basic** feature"
+  icon = "fas fa-check"
+
+[[features]]
+  text = "**Email** support"
+  icon = "fas fa-check"
++++
 ```
 </details>

--- a/layouts/partials/fragments/pricing.html
+++ b/layouts/partials/fragments/pricing.html
@@ -55,6 +55,9 @@
         </div>
       {{- end }}
       <div class="row">
+        {{- if eq (len $items) 0 -}}
+          {{- partial "helpers/empty-subpath.html" (dict "context" "pricing" "root" $) -}}
+        {{- end -}}
         {{- range (sort $items ".Params.weight") }}
           <div class="col-lg-4 col-md-6 col-12 py-2 pricing-plan {{- if .Params.highlight }} pricing-plan-highlight {{- end -}}">
             <div class="card">

--- a/layouts/partials/helpers/empty-subpath.html
+++ b/layouts/partials/helpers/empty-subpath.html
@@ -1,5 +1,5 @@
 <div class="row w-100 justify-content-center mx-0">
   <div class="alert alert-danger text-center">
-    {{- printf "Currently there is no configured %s content files present. To add new members add a content file within %s" .context .root.fallthrough.file_path -}}
+    {{- printf "Currently there is no configured %s content files present. To add new members add a content file within %s" .context .root.file_path -}}
   </div>
 </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Some fragments (portfolio, pricing, items, member) use subpath but had some issues. Examples lacked subpath items code examples, pricing fragment wasn't available in `/dev/empty-subitems` and didn't have a warning in case of no items.

**Which issue this PR fixes:**
fixes #362 

**Release note:**
```release-note
- pricing: Add warning message in case there are no items available
```