### PR TITLE
Add alignment support to header helper

### DIFF
--- a/exampleSite/content/fragments/buttons/buttons.md
+++ b/exampleSite/content/fragments/buttons/buttons.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Buttons Fragment"
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 
 [[buttons]]
   text = "Button"

--- a/exampleSite/content/fragments/buttons/code-buttons.md
+++ b/exampleSite/content/fragments/buttons/code-buttons.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Buttons Fragment"
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 
 [[buttons]]
   text = "Button"

--- a/exampleSite/content/fragments/contact/code-contact.md
+++ b/exampleSite/content/fragments/contact/code-contact.md
@@ -15,6 +15,7 @@ form_name = "defaultContact"
 
 title = "Contact fragment"
 subtitle  = "*not working on demo page*"
+#title_align = "left" # Default is center, can be left, right or center
 
 # PostURL can be used with backends such as mailout from caddy
 post_url = "https://example.com/mailout" #default: formspree.io

--- a/exampleSite/content/fragments/contact/contact.md
+++ b/exampleSite/content/fragments/contact/contact.md
@@ -8,6 +8,7 @@ form_name = "defaultContact"
 
 title = "Contact fragment"
 subtitle  = "*not working on demo page*"
+#title_align = "left" # Default is center, can be left, right or center
 
 # PostURL can be used with backends such as mailout from caddy
 post_url = "https://example.com/mailout" #default: formspree.io

--- a/exampleSite/content/fragments/content/code-content-sidebar-right.md
+++ b/exampleSite/content/fragments/content/code-content-sidebar-right.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Content with sidebar"
 subtitle = "Split in two!"
+#title_align = "left" # Default is center, can be left, right or center
 
 [sidebar]
   title = "Sidebar"

--- a/exampleSite/content/fragments/content/code-content-sidebar.md
+++ b/exampleSite/content/fragments/content/code-content-sidebar.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Content with sidebar"
 subtitle = "Split in two!"
+#title_align = "left" # Default is center, can be left, right or center
 
 [sidebar]
   title = "Sidebar"

--- a/exampleSite/content/fragments/content/code-content.md
+++ b/exampleSite/content/fragments/content/code-content.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Content without sidebar"
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a lorem urna. Quisque in neque malesuada, sollicitudin nunc porttitor, ornare est. Praesent ante enim, bibendum sed hendrerit et, iaculis laoreet felis. Morbi efficitur dui sit amet orci porttitor, nec tincidunt turpis elementum. Suspendisse rutrum, mi ac sollicitudin blandit, eros sem tincidunt enim, vitae feugiat turpis eros ut diam. Nunc hendrerit, nibh vitae dignissim pretium, magna nulla lacinia massa, et interdum lacus purus ultricies lacus. Nulla tincidunt quis lacus in posuere. Integer urna lorem, ultricies ut est vel, rhoncus euismod metus. Vestibulum luctus maximus massa, ut egestas est iaculis in. Nunc nisi dolor, sodales et imperdiet ut, lacinia ac justo. Phasellus ultrices risus cursus maximus lobortis. Vestibulum sagittis elementum dignissim. Suspendisse iaculis venenatis nisl, sed bibendum urna. Aliquam quis pellentesque tortor. Sed sed cursus nisl. Aenean eu lorem condimentum, feugiat mauris vitae, hendrerit tellus.

--- a/exampleSite/content/fragments/content/content-sidebar-right.md
+++ b/exampleSite/content/fragments/content/content-sidebar-right.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Content with sidebar"
 subtitle = "Split in two!"
+#title_align = "left" # Default is center, can be left, right or center
 
 [sidebar]
   title = "Sidebar"

--- a/exampleSite/content/fragments/content/content-sidebar.md
+++ b/exampleSite/content/fragments/content/content-sidebar.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Content with sidebar"
 subtitle = "Split in two!"
+#title_align = "left" # Default is center, can be left, right or center
 
 [sidebar]
   title = "Sidebar"

--- a/exampleSite/content/fragments/content/content.md
+++ b/exampleSite/content/fragments/content/content.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Content without sidebar"
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur a lorem urna. Quisque in neque malesuada, sollicitudin nunc porttitor, ornare est. Praesent ante enim, bibendum sed hendrerit et, iaculis laoreet felis. Morbi efficitur dui sit amet orci porttitor, nec tincidunt turpis elementum. Suspendisse rutrum, mi ac sollicitudin blandit, eros sem tincidunt enim, vitae feugiat turpis eros ut diam. Nunc hendrerit, nibh vitae dignissim pretium, magna nulla lacinia massa, et interdum lacus purus ultricies lacus. Nulla tincidunt quis lacus in posuere. Integer urna lorem, ultricies ut est vel, rhoncus euismod metus. Vestibulum luctus maximus massa, ut egestas est iaculis in. Nunc nisi dolor, sodales et imperdiet ut, lacinia ac justo. Phasellus ultrices risus cursus maximus lobortis. Vestibulum sagittis elementum dignissim. Suspendisse iaculis venenatis nisl, sed bibendum urna. Aliquam quis pellentesque tortor. Sed sed cursus nisl. Aenean eu lorem condimentum, feugiat mauris vitae, hendrerit tellus.

--- a/exampleSite/content/fragments/embed/code-embed_subscribe.md
+++ b/exampleSite/content/fragments/embed/code-embed_subscribe.md
@@ -14,7 +14,8 @@ background = "secondary"
 form_name = "subscribe"
 
 #title = ""
-#subtitle  = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 
 # Embed a form via an iframe
 # Mailerlite is one example of a working provider.

--- a/exampleSite/content/fragments/embed/code-embed_video.md
+++ b/exampleSite/content/fragments/embed/code-embed_video.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Embed Fragment"
 subtitle = "Easily embed media (videos, iframes etc.)"
+#title_align = "left" # Default is center, can be left, right or center
 
 media_source = "https://www.youtube-nocookie.com/embed/lXpf4kIxygU?rel=0&amp;showinfo=0"
 #media = '<iframe class="embed-responsive-item" src="https://www.youtube-nocookie.com/embed/lXpf4kIxygU?rel=0&amp;showinfo=0" allowfullscreen></iframe>'
@@ -22,4 +23,3 @@ media_source = "https://www.youtube-nocookie.com/embed/lXpf4kIxygU?rel=0&amp;sho
 +++
 ```
 </details>
-

--- a/exampleSite/content/fragments/embed/embed_subscribe.md
+++ b/exampleSite/content/fragments/embed/embed_subscribe.md
@@ -7,7 +7,8 @@ background = "secondary"
 form_name = "subscribe"
 
 #title = ""
-#subtitle  = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 
 # Embed a form via an iframe
 # Mailerlite is one example of a working provider.

--- a/exampleSite/content/fragments/embed/embed_video.md
+++ b/exampleSite/content/fragments/embed/embed_video.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Embed Fragment"
 subtitle = "Easily embed media (videos, iframes etc.)"
+#title_align = "left" # Default is center, can be left, right or center
 
 media_source = "https://www.youtube-nocookie.com/embed/lXpf4kIxygU?rel=0&amp;showinfo=0"
 #media = '<iframe class="embed-responsive-item" src="https://www.youtube-nocookie.com/embed/lXpf4kIxygU?rel=0&amp;showinfo=0" allowfullscreen></iframe>'

--- a/exampleSite/content/fragments/header/code-header.md
+++ b/exampleSite/content/fragments/header/code-header.md
@@ -13,6 +13,7 @@ weight = 110
 background = "secondary"
 title = "Section Header Fragment"
 subtitle = "Even linking is possible. This fragment can be used for related sections so linking is easier."
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/header/header.md
+++ b/exampleSite/content/fragments/header/header.md
@@ -6,4 +6,5 @@ weight = 110
 background = "secondary"
 title = "Section Header Fragment"
 subtitle = "Even linking is possible. This fragment can be used for related sections so linking is easier."
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/code-items-no-content.md
+++ b/exampleSite/content/fragments/items/code-items-no-content.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Items Fragment with no content"
 subtitle= "Column based items with icons"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-items-only.md
+++ b/exampleSite/content/fragments/items/code-items-only.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 #title = ""
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-items.md
+++ b/exampleSite/content/fragments/items/code-items.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Items Fragment"
 subtitle= "Column based items with icons"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-logos-no-content.md
+++ b/exampleSite/content/fragments/items/code-logos-no-content.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 
 ```

--- a/exampleSite/content/fragments/items/code-logos-only.md
+++ b/exampleSite/content/fragments/items/code-logos-only.md
@@ -11,6 +11,10 @@ fragment = "items"
 date = "2017-10-04"
 weight = 150
 background = "secondary"
+
+#title = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/code-logos.md
+++ b/exampleSite/content/fragments/items/code-logos.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/items/items-no-content/index.md
+++ b/exampleSite/content/fragments/items/items-no-content/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 title = "Items Fragment with no content"
 subtitle= "Column based items with icons"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/items-only/index.md
+++ b/exampleSite/content/fragments/items/items-only/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 #title = ""
 #subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/items/index.md
+++ b/exampleSite/content/fragments/items/items/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 title = "Items Fragment"
 subtitle= "Column based items with icons"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/logos-no-content/index.md
+++ b/exampleSite/content/fragments/items/logos-no-content/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/logos-only/index.md
+++ b/exampleSite/content/fragments/items/logos-only/index.md
@@ -4,4 +4,8 @@ fragment = "items"
 date = "2017-10-04"
 weight = 150
 background = "secondary"
+
+#title = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/items/logos/index.md
+++ b/exampleSite/content/fragments/items/logos/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 title = "Items Fragment with images"
 subtitle= "Column based items with images"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/list/code-list-tiled.md
+++ b/exampleSite/content/fragments/list/code-list-tiled.md
@@ -9,6 +9,10 @@ weight = 121
 fragment = "list"
 weight = 150
 
+title = "List fragment with tiled layout"
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
+
 background = "secondary"
 count = 5 # Default value is 10
 section = "dev/blog" # Default value is current section

--- a/exampleSite/content/fragments/list/code-list.md
+++ b/exampleSite/content/fragments/list/code-list.md
@@ -9,6 +9,10 @@ weight = 111
 fragment = "list"
 weight = 150
 
+title = "List fragment with list layout"
+#subtitle = ""
+title_align = "left" # Default is center, can be left, right or center
+
 background = "secondary"
 count = 5 # Default value is 10
 section = "dev/blog" # Default value is current section

--- a/exampleSite/content/fragments/list/list-tiled.md
+++ b/exampleSite/content/fragments/list/list-tiled.md
@@ -2,6 +2,10 @@
 fragment = "list"
 weight = 120
 
+title = "List fragment with tiled layout"
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
+
 background = "secondary"
 count = 5 # Default value is 10
 section = "dev/blog" # Default value is current section

--- a/exampleSite/content/fragments/list/list.md
+++ b/exampleSite/content/fragments/list/list.md
@@ -2,6 +2,10 @@
 fragment = "list"
 weight = 110
 
+title = "List fragment with list layout"
+#subtitle = ""
+title_align = "left" # Default is center, can be left, right or center
+
 background = "secondary"
 count = 5 # Default value is 10
 section = "dev/blog" # Default value is current section

--- a/exampleSite/content/fragments/member/code-members.md
+++ b/exampleSite/content/fragments/member/code-members.md
@@ -13,6 +13,7 @@ weight = 120
 background = "secondary"
 
 title = "Members fragment - Multiple members"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/member/code-single-member.md
+++ b/exampleSite/content/fragments/member/code-single-member.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Single Member Fragment"
 #subtitle = "Highly motivated Gophers"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/member/members/index.md
+++ b/exampleSite/content/fragments/member/members/index.md
@@ -6,4 +6,5 @@ weight = 120
 background = "secondary"
 
 title = "Members fragment - Multiple members"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/member/single-member/index.md
+++ b/exampleSite/content/fragments/member/single-member/index.md
@@ -7,4 +7,5 @@ background = "secondary"
 
 title = "Single Member Fragment"
 #subtitle = "Highly motivated Gophers"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/portfolio/code-portfolio.md
+++ b/exampleSite/content/fragments/portfolio/code-portfolio.md
@@ -13,6 +13,7 @@ background = "secondary"
 
 title = "Portfolio Fragment"
 subtitle = "Displaying animals with links and modals"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/portfolio/portfolio/index.md
+++ b/exampleSite/content/fragments/portfolio/portfolio/index.md
@@ -6,4 +6,5 @@ background = "secondary"
 
 title = "Portfolio Fragment"
 subtitle = "Displaying animals with links and modals"
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/pricing/code-pricing.md
+++ b/exampleSite/content/fragments/pricing/code-pricing.md
@@ -13,6 +13,7 @@ weight = 100
 
 title = "Pricing fragment"
 subtitle = "Can be linked to 3rd party payment services"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 
 Pricing fragment supports **markdown** as it's subtitle.  

--- a/exampleSite/content/fragments/pricing/pricing/index.md
+++ b/exampleSite/content/fragments/pricing/pricing/index.md
@@ -5,6 +5,7 @@ background = "secondary"
 
 title = "Pricing fragment"
 subtitle = "Can be linked to 3rd party payment services"
+#title_align = "left" # Default is center, can be left, right or center
 +++
 
 Pricing fragment supports **markdown** as it's subtitle.  

--- a/exampleSite/content/fragments/search/code-search.md
+++ b/exampleSite/content/fragments/search/code-search.md
@@ -9,6 +9,10 @@ fragment = "search"
 weight = 110
 title = "Search"
 background = "secondary"
+
+#title = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/search/search.md
+++ b/exampleSite/content/fragments/search/search.md
@@ -3,4 +3,8 @@ fragment = "search"
 weight = 110
 title = "Search"
 background = "secondary"
+
+#title = ""
+#subtitle = ""
+#title_align = "left" # Default is center, can be left, right or center
 +++

--- a/exampleSite/content/fragments/table/code-table.md
+++ b/exampleSite/content/fragments/table/code-table.md
@@ -14,6 +14,7 @@ background = "secondary"
 
 title = "Table Fragment"
 subtitle= "Tables are responsive by default"
+#title_align = "left" # Default is center, can be left, right or center
 
 [header]
   [[header.values]]

--- a/exampleSite/content/fragments/table/table.md
+++ b/exampleSite/content/fragments/table/table.md
@@ -7,6 +7,7 @@ background = "secondary"
 
 title = "Table Fragment"
 subtitle= "Tables are responsive by default"
+#title_align = "left" # Default is center, can be left, right or center
 
 [header]
   [[header.values]]

--- a/layouts/partials/fragments/pricing.html
+++ b/layouts/partials/fragments/pricing.html
@@ -22,7 +22,7 @@
           </div>
         </div>
       {{- end }}
-      <div class="row">
+      <div class="row {{- if not .Content -}}{{ print " pt-4" }}{{ end }}">
         {{- if eq (len $items) 0 -}}
           {{- partial "helpers/empty-subpath.html" (dict "context" "pricing" "root" $) -}}
         {{- end -}}

--- a/layouts/partials/fragments/search.html
+++ b/layouts/partials/fragments/search.html
@@ -8,7 +8,7 @@
     {{- printf " bg-%s" $bg -}}
   ">
   <div class="container py-5">
-      {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
+    {{- partial "helpers/section-header.html" (dict "bg" $bg "params" .Params) }}
     <div class="row w-100 justify-content-center mx-0">
       <form action="{{ "search" | absURL }}" class="mt-0">
         <div class="input-group my-0">

--- a/layouts/partials/helpers/section-header.html
+++ b/layouts/partials/helpers/section-header.html
@@ -1,11 +1,14 @@
 {{- $bg := .bg -}}
+{{- $align := .params.align | default "center" -}}
+{{- $subtitle_align := .params.subtitle_align | default $align -}}
 {{- with .params.title }}
-  <div class="row">
-    <div class="col text-center py-3
-      {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
+  <div class="row mx-0">
+    <div class="col
+      {{- printf " text-%s" $align -}}
+      {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
         {{- printf " text-%s" "dark" -}}
       {{- else -}}
-        {{- printf " text-%s" "secondary" -}}
+        {{- printf " text-%s" "light" -}}
       {{- end -}}
     ">
       <h2>
@@ -14,9 +17,10 @@
     </div>
   </div>
 {{- end -}}
-{{- with .params.subtitle }}
-  <div class="row">
-    <div class="col text-center pb-4
+{{- with .params.subtitle -}}
+  <div class="row mx-0">
+    <div class="col pt-4 pb-0
+      {{- printf " text-%s" $subtitle_align -}}
       {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
         {{- printf " text-%s" "dark" -}}
       {{- else -}}

--- a/layouts/partials/helpers/section-header.html
+++ b/layouts/partials/helpers/section-header.html
@@ -1,6 +1,5 @@
 {{- $bg := .bg -}}
-{{- $align := .params.header_align | default "center" -}}
-{{- $subtitle_align := .params.subtitle_align | default $align -}}
+{{- $align := .params.title_align | default "center" -}}
 {{- with .params.title }}
   <div class="row mx-0">
     <div class="col
@@ -20,7 +19,7 @@
 {{- with .params.subtitle -}}
   <div class="row mx-0">
     <div class="col pt-4 pb-0
-      {{- printf " text-%s" $subtitle_align -}}
+      {{- printf " text-%s" $align -}}
       {{- if or (eq $bg "secondary") (eq $bg "primary") -}}
         {{- printf " text-%s" "dark" -}}
       {{- else -}}

--- a/layouts/partials/helpers/section-header.html
+++ b/layouts/partials/helpers/section-header.html
@@ -1,5 +1,5 @@
 {{- $bg := .bg -}}
-{{- $align := .params.align | default "center" -}}
+{{- $align := .params.header_align | default "center" -}}
 {{- $subtitle_align := .params.subtitle_align | default $align -}}
 {{- with .params.title }}
   <div class="row mx-0">


### PR DESCRIPTION
**What this PR does / why we need it**:
Header helper doesn't support alignment. This PR adds the previous helper fragment features to the header helper and supports alignment.

**Release note**:
```release-note
- global: All fragments now support alignment of the title and subtitle
- BREAKING: header: `align` variable is changed to `header_align`
```
