### PR TITLE
Fix content fragment images max-width

### DIFF
--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -45,7 +45,7 @@
               <img src="{{ partial "helpers/image.html" (dict "root" . "asset" .Params.asset) }}" alt="{{ .Params.subtitle | default .Params.title }}" class="img-fluid mb-4">
             </div>
           {{- end -}}
-          <div class="col-12
+          <div class="col-12 content
             {{- partial "helpers/text-color.html" (dict "self" $self "light" "muted") -}}
           ">
             {{ $self.Content | markdownify }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `.content` class to content container of content fragment, fixing max-width issue for images

**Which issue this PR fixes**:
fixes #376 

**Special notes for your reviewer**:

**Release note**:
```release-note
- content: Fix max-width of images in the content
```
