### PR TITLE
Add support for frontmatter summary in content fragment for list fragment

### DIFF
--- a/exampleSite/content/dev/blog/article-1/index.md
+++ b/exampleSite/content/dev/blog/article-1/index.md
@@ -10,6 +10,12 @@ title = "First sample blog"
 display_date = true
 date = "2018-07-06"
 
+summary = """
+Sometimes you need a **markdown** summary and that's not possible to do with
+[Hugo](https://gohugo.io). Lorem ipsum dolor sit amet, consectetur adipiscing
+elit. Curabitur a lorem urna.
+"""
+
 [asset]
   image = "image.png"
 +++

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -120,7 +120,7 @@
                     {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}
                   ">
                     {{- range $content_page }}
-                      {{ .Summary }}
+                      {{ cond (isset .Params "summary") (.Params.summary | markdownify) .Summary }}
                       {{- if and (not $self.Params.tiled) (ne $self.Params.read_more false) -}}
                         {{- if or $self.Params.read_more .Truncated }}
                           <a class="badge 


### PR DESCRIPTION
**What this PR does / why we need it**:
List fragment would render content fragment's `.Params.summary` if it's available instead of Hugo generated `.Summary`

**Which issue this PR fixes**:
fixes #321 

**Special notes for your reviewer**:

**Release note**:
```release-note
- content: New frontmatter variable: summary: string, supports markdown
- list: Add ability to use content fragment's `.Params.summary` in case it's present and markdownify it.
```
