### PR TITLE
Fix items fragment column header color and content padding

### DIFF
--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -45,7 +45,9 @@
                   </div>
                   <div class="row justify-content-center text-center">
                     {{- if $item.title }}
-                      <h4 class="mb-3">
+                      <h4 class="mb-3
+                        {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}
+                      ">
                         {{- $item.title | markdownify -}}
                       </h4>
                     {{- end -}}
@@ -55,7 +57,7 @@
                 {{- else }}
                   </div>
                 {{- end }}
-                <div class="row justify-content-center text-center">
+                <div class="row justify-content-center text-center p-2">
                   {{- if .Content }}
                     <div class="
                       {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix column title color in items fragment
Fix content in items fragment columns

**Which issue this PR fixes**:
fixes #397 

