### PR TITLE
Fix contact form

### DIFF
--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -19,9 +19,9 @@
           class="contact"
           method="POST"
           name="{{- .Params.form_name | default (printf "contact-form-%s" .Name) }}"
-          id="{{ printf "contact-form-%s" .Name }}"
+          id="{{- .Params.form_name | default (printf "contact-form-%s" .Name) }}"
           {{- if .Params.netlify -}}
-            {{- safeHTMLAttr (print " netlify-recaptcha netlify data-has-netlify=\"true\"") -}}
+            {{- safeHTMLAttr (print " data-has-netlify=\"true\" netlify") -}}
           {{- else -}}
             {{- safeHTMLAttr (printf " action=\"%s\"" (.Params.post_url | default (printf "https://formspree.io/%s" .Params.email))) -}}
           {{- end }}>
@@ -110,13 +110,13 @@
                     {{- i18n "contact.defaultJsError" }} {{ .Params.email }}.
                   </div>
                 </noscript>
-                {{- with .Params.recaptcha }}
+                {{- if and .Params.recaptcha (not .Params.netlify) }}
                   <div class="g-recaptcha-container">
                     <span class="g-recaptcha-filler"></span>
                     <button
                       class="g-recaptcha btn btn-primary"
                       type="submit"
-                      data-sitekey="{{ .sitekey }}"
+                      data-sitekey="{{ .Params.recaptcha.sitekey }}"
                       data-size="invisible"
                       data-badge="inline"
                       data-callback="onContactCaptcha"
@@ -127,7 +127,7 @@
                   </div>
                 {{- else }}
                   {{- if .Params.netlify }}
-                    <div data-netlify-recaptcha></div>
+                    <div netlify-recaptcha></div>
                   {{- end }}
                   <button
                     class="btn


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Parly fixes netlify contact form submissions.

**Special notes for your reviewer**:
The netlify recaptcha configuration was a mixture of custom recaptcha and netlify injected recaptcha before. This is moved into the correct configuration for the netlify injected recaptcha.

Currently still a problem is that netlify seems to inject an additional recaptcha after submission aka it seems that it's ignoring the first recaptcha response, which is actually send in the correct POST request.

Also still annoying is the thank you notice being delivered out of page instead of inline.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
