### PR TITLE
Update webpack link in docs section

### DIFF
--- a/exampleSite/content/docs/_index/content.md
+++ b/exampleSite/content/docs/_index/content.md
@@ -15,4 +15,4 @@ Each page within a Syna based website is created using fragments.
 
 If anything is not documented or needs more details, feel free to open an issue or contribute by opening a pull request.
 
-*See how you can contribute with our [contribution guide](/CONTRIBUTING.md).*
+*See how you can contribute with our [contribution guide](https://github.com/okkur/syna/blob/master/CONTRIBUTING.md).*

--- a/exampleSite/content/docs/development/content.md
+++ b/exampleSite/content/docs/development/content.md
@@ -33,7 +33,7 @@ Within the `assets/js/` directory there is an `index.js` file that is the main s
 Every other script is needed by the fragment of the same name.
 For example `hero.js` is needed by the `hero` fragment.
 
-If you want to add an extra script for a specific fragment, you need to add that script as an entry point in the [webpack configuration file](/webpack.config.js).
+If you want to add an extra script for a specific fragment, you need to add that script as an entry point in the [webpack configuration file](https://github.com/okkur/syna/blob/master/webpack.config.js).
 Then import that script inside the fragment (using the `script` tag).
 
 Transpiled and bundled JS files are located inside `assets/scripts/` directory and are generated using Webpack.


### PR DESCRIPTION
**What this PR does / why we need it**:
Webpack's config file's link in the `/docs/development` page is fixed.

**Which issue this PR fixes**:
fixes #430 