### PR TITLE
Add fallback favicon and and fix logo url in nav fragment

### DIFF
--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -19,11 +19,11 @@
 {{- end -}}>
   <div class="container">
     {{- if .Params.asset.image }}
-      <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">
+      <a class="navbar-brand py-0" href="{{ "#" | relLangURL }}">
         <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset) }}" height="35" class="d-inline-block align-top" alt="{{ .Params.asset.text }}">
       </a>
     {{- else }}
-      <a class="navbar-brand py-0" href="{{ "#page-top" | relLangURL }}">
+      <a class="navbar-brand py-0" href="{{ "#" | relLangURL }}">
         {{- .Params.asset.text -}}
       </a>
     {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,7 +77,9 @@
     {{- end -}}
 
     {{ if and (not .favicon) (not .favicon_png) (not .favicon_svg) }}
-      <link rel="icon" type="image/svg+xml" href="favicon.svg">
+      <link rel="icon" href="/favicon.png">
+      <link rel="apple-touch-icon-precomposed" href="/favicon.png">
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     {{ end }}
   {{- end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -75,6 +75,10 @@
     {{- with .favicon_svg }}
       <link rel="icon" type="image/svg+xml" href="{{ . | relLangURL }}">
     {{- end -}}
+
+    {{ if and (not .favicon) (not .favicon_png) (not .favicon_svg) }}
+      <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    {{ end }}
   {{- end }}
 
   {{- partial "custom/css.html" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add fallback favicon in case no favicon is set in config
- Fix logo url in navbar fragment

**Which issue this PR fixes**:
fixes #496 

**Release note**:
```release-note
- Added fallback favicon in case no favicon is set in config
- Logo's url in navbar fragment now always moves the page to top
```
