### PR TITLE
Prototype: Create new grid fragment

### DIFF
--- a/exampleSite/content/fragments/grid/config.md
+++ b/exampleSite/content/fragments/grid/config.md
@@ -1,0 +1,19 @@
++++
+fragment = "config"
+
+[[config]]
+  type = "css"
+  html = """
+<style>
+.bg-custom-column {
+  background-color: rgba(86,61,124,.15);
+  border: 1px solid rgba(86,61,124,.2);
+}
+
+.bg-custom-column h2 {
+  color: black;
+  color: var(--dark);
+}
+</style>
+"""
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-1.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-1.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 1"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-2.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-2.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 2"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-3.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-3.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 3"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-4.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-4.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 4"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-5.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-5.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 5"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-6.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-6.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 6"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-7.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-7.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 7"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/header-8.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/header-8.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-custom-columns/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 8"
++++

--- a/exampleSite/content/fragments/grid/grid-custom-columns/index.md
+++ b/exampleSite/content/fragments/grid/grid-custom-columns/index.md
@@ -1,0 +1,13 @@
++++
+fragment = "grid"
+weight = 130
+
+title = "Grid with custom columns"
+subtitle = "Col spans of 3 and 9"
+
+[[column]]
+  class = "col-sm-3"
+
+[[column]]
+  class = "col-sm-9"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-1.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-1.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 1"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-2.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-2.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 2"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-3.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-3.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 3"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-4.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-4.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 4"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-5.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-5.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 5"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-6.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-6.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 6"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-7.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-7.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 7"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/header-8.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/header-8.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid-two-column/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 8"
++++

--- a/exampleSite/content/fragments/grid/grid-two-column/index.md
+++ b/exampleSite/content/fragments/grid/grid-two-column/index.md
@@ -1,0 +1,9 @@
++++
+fragment = "grid"
+weight = 120
+
+title = "Two column grid"
+subtitle = "Col span of 6"
+
+column_span = 6
++++

--- a/exampleSite/content/fragments/grid/grid/header-1.md
+++ b/exampleSite/content/fragments/grid/grid/header-1.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 1"
++++

--- a/exampleSite/content/fragments/grid/grid/header-2.md
+++ b/exampleSite/content/fragments/grid/grid/header-2.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 2"
++++

--- a/exampleSite/content/fragments/grid/grid/header-3.md
+++ b/exampleSite/content/fragments/grid/grid/header-3.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 3"
++++

--- a/exampleSite/content/fragments/grid/grid/header-4.md
+++ b/exampleSite/content/fragments/grid/grid/header-4.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 4"
++++

--- a/exampleSite/content/fragments/grid/grid/header-5.md
+++ b/exampleSite/content/fragments/grid/grid/header-5.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 5"
++++

--- a/exampleSite/content/fragments/grid/grid/header-6.md
+++ b/exampleSite/content/fragments/grid/grid/header-6.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 6"
++++

--- a/exampleSite/content/fragments/grid/grid/header-7.md
+++ b/exampleSite/content/fragments/grid/grid/header-7.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 7"
++++

--- a/exampleSite/content/fragments/grid/grid/header-8.md
+++ b/exampleSite/content/fragments/grid/grid/header-8.md
@@ -1,0 +1,11 @@
++++
+fragment = "header"
+weight = 10
+slot = "grid/column"
+
+background = "custom-column"
+force_background = true
+
+
+title = "Item 8"
++++

--- a/exampleSite/content/fragments/grid/grid/index.md
+++ b/exampleSite/content/fragments/grid/grid/index.md
@@ -1,0 +1,7 @@
++++
+fragment = "grid"
+weight = 110
+
+title = "Default grid - Four columns"
+subtitle = "Col span of 3"
++++

--- a/exampleSite/content/fragments/grid/index.md
+++ b/exampleSite/content/fragments/grid/index.md
@@ -1,0 +1,17 @@
++++
+fragment = "content"
+weight = 100
+
+title = "Grid"
+background = "light"
++++
+
+Grid fragment creates a [Bootstrap grid](https://getbootstrap.com/docs/4.1/layout/grid/) layout, with customizable columns that can be used to create custom layouts for a page.
+
+The columns are by default using `.col-sm-3` class but this can be customized either generally or column by column.
+
+Columns are filled by rendering fragments assigned to the `column` slot of the fragment.
+
+- [Default grid - Four columns](#grid)
+- [Two column grid](#grid-two-column)
+- [Grid with custom columns](#grid-custom-columns)

--- a/layouts/partials/fragments/grid.html
+++ b/layouts/partials/fragments/grid.html
@@ -1,0 +1,31 @@
+{{- $self := .self -}}
+{{- $page_scratch := .page_scratch -}}
+
+{{/* Slot information */}}
+{{- $data := dict "page" $.page "content_fragment" $self -}}
+{{- $slot := "column" -}}
+{{- $slot_name := printf "%s/%s" .Name $slot -}}
+
+{{/* Column information */}}
+{{- $is_column_general := not (isset .Params "column") -}}
+{{- $columns := .Params.column | default slice -}}
+{{- $column_count := len $columns -}}
+
+{{- $bg := .self.Scratch.Get "bg" }}
+
+{{ "<!-- Grid -->" | safeHTML }}
+
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+  {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
+
+  {{- partial "helpers/slot.html" (dict "root" $ "slot" $slot "data" $data "should_render" false) -}}
+  {{- $slots := ($page_scratch.Get $slot_name) | default slice }}
+  <div class="row">
+    {{- range $index, $fragment := sort $slots "Params.weight" -}}
+      {{- $col := mod $index ($column_count | default 1) -}}
+      <div class="{{ cond $is_column_general (printf "col-sm-%d" ($.Params.column_span | default 3)) (index $columns $col).class }}">
+        {{- partial "helpers/slot-renderer.html" (dict "page_scratch" $page_scratch "data" $data "root" $ "slot" $slot "fragment" $fragment) -}}
+      </div>
+    {{- end -}}  
+  </div>
+{{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}

--- a/layouts/partials/helpers/container.html
+++ b/layouts/partials/helpers/container.html
@@ -3,7 +3,7 @@
 {{- end }}
 {{- if .start }}
 <section id="{{ .Name }}" class="fragment">
-  {{- if ne .in_slot true }}
+  {{- if or (ne .in_slot true) (eq .Params.force_background true) }}
     <div class="container-fluid
       {{- printf " bg-%s" .bg -}}
     ">

--- a/layouts/partials/helpers/slot-renderer.html
+++ b/layouts/partials/helpers/slot-renderer.html
@@ -1,0 +1,14 @@
+{{- $page_scratch := .page_scratch -}}
+{{- $data := .data -}}
+{{- $root := .root -}}
+{{- $slot := .slot -}}
+{{- $fragment := .fragment -}}
+
+{{/* Cleanup .Name to be more useful within fragments */}}
+{{- $name := cond (eq $root.page $fragment) $fragment.File.BaseFileName (strings.TrimSuffix ".md" (replace $fragment.Name "/index.md" "")) -}}
+{{- $bg := $fragment.Params.background | default "light" -}}
+{{- $fragment.Scratch.Set "bg" $bg -}}
+
+{{- $file_path := strings.TrimSuffix ".md" (replace $fragment.File.Path "/index.md" "") -}}
+{{- $context := dict "page_scratch" $page_scratch "root" $root.root "Site" $root.Site "page" $root.page "resources" $root.resources "self" $fragment "Params" $fragment.Params "Name" $name "file_path" $file_path "nested_level" (add ($root.nested_level | default 0) 1) "in_slot" true "data" ($data | default (dict)) -}}
+{{- partial (print "fragments/" (strings.TrimPrefix (printf "%s/%s:" $root.self.File.BaseFileName $slot) $fragment.Params.fragment) ".html") $context -}}

--- a/layouts/partials/helpers/slot.html
+++ b/layouts/partials/helpers/slot.html
@@ -1,9 +1,22 @@
+{{/* This helper registers a slot, find all the fragments (previously registered
+  in the fragments helpers) that have their slot variable set to this slot's
+  name and renders them */}}
+
 {{- $slot := .slot -}}
-{{- $slot_name := printf "%s/%s" .root.self.File.BaseFileName $slot -}}
-{{- $nested_level := .root.nested_level | default 0 -}}
+{{- $slot_name := printf "%s/%s" .root.Name $slot -}}
 {{- $page_scratch := .root.page_scratch -}}
 {{- $root := .root -}}
+{{- $data := .data -}}
+{{- $should_render := .should_render | default true -}}
 
+{{/* This variable is to determine how deep is this slot. It will actually be
+  set in the fragment context when rendering the fragments in the slot and will
+  be passed down when slot is registered. The default value is set to 0 because
+  if the variable is not defined, the parent fragment is rendered directly in
+  the page.*/}}
+{{- $nested_level := .root.nested_level | default 0 -}}
+
+{{/* Find fragments that are to be rendered on this slot */}}
 {{- $page_scratch.Set $slot_name (slice) -}}
 {{- range ($page_scratch.Get "page_fragments") -}}
   {{- if and (not .Params.disabled) (isset .Params "fragment") (eq .Params.slot $slot_name) -}}
@@ -11,16 +24,14 @@
   {{- end -}}
 {{- end -}}
 
+{{/* Store all found fragments in the page */}}
 {{ $page_scratch.Add "page_slots" (dict "slot" $slot_name "fragments" ($page_scratch.Get $slot_name)) }}
-{{- if lt $nested_level 2 -}}
-  {{- range sort ($page_scratch.Get $slot_name) "Params.weight" -}}
-    {{/* Cleanup .Name to be more useful within fragments */}}
-    {{- $name := cond (eq $.root.page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" "")) -}}
-    {{- $bg := .Params.background | default "light" -}}
-    {{- .Scratch.Set "bg" $bg -}}
 
-    {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
-    {{- $context := dict "page_scratch" $page_scratch "root" $root.root "Site" $root.Site "page" $root.page "resources" $root.resources "self" . "Params" .Params "Name" $name "file_path" $file_path "nested_level" (add $nested_level 1) "in_slot" true "data" ($.data | default (dict)) -}}
-    {{- partial (print "fragments/" (strings.TrimPrefix (printf "%s/%s:" $.root.self.File.BaseFileName $slot) .Params.fragment) ".html") $context -}}
+{{/* Don't render any of the fragments if the parent fragment is already two
+  levels deep or should_render variable is set to false */}}
+{{- if and (lt $nested_level 2) (ne $should_render false) -}}
+  {{/* Render fragments */}}
+  {{- range sort ($page_scratch.Get $slot_name) "Params.weight" -}}
+    {{- partial "helpers/slot-renderer.html" (dict "page_scratch" $page_scratch "data" $data "root" $root "slot" $slot "fragment" .) -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Create new grid fragment

**Special notes for your reviewer**:
I realize there are no issues related to this PR, I just thought it would be a good new feature for a more advanced case.

To create this I had to split the `slot` helper to work more closely to how `fragments` helper works. It now just detects how deep the slot is and if it's below the `nested_level` variable, collects the fragments that are going to be rendered there. Then the new `slot-renderer` helper renders the fragments.

This is done to allow wrapping each fragment in the slot with a custom template. I use this to wrap the fragments with a `div.col-...`.

This can be used to fix #545 

If you think this is unnecessary or needs enhancements or is confusing, let me know. If not, it needs documentation and we can provide simpler layout fragments using this one later on.

**Release note**:
```release-note
- Grid: New grid fragment
```
