### PR TITLE
Fix global fragments not working on every section

### DIFF
--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -108,7 +108,7 @@
     {{- else if ge $index 1 -}}
       {{/* Sections between the first and last are found and their _global directories
         are taken into account */}}
-      {{- $directory := (delimit (first (add $index 1) $sections) "/") -}}
+      {{- $directory := (delimit (first (add $index 1) ($page_scratch.Get "sections")) "/") -}}
       {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
     {{- else -}}
       {{/* First section is always the root directory and we look for it's _global


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces old variable with a more complete version of it, fixing section globals not working on the section level when the page is deeper than 2 sections.