### PR TITLE
Upgrade to hugo v0.55.5

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,8 @@
 {{- define "main" -}}
   {{/* In some edge cases, .CurrentSection is not available. If it's not
-    available the build would break since we need .CurrentSection.Dir later on. */}}
+    available the build would break since we need .CurrentSection.File.Dir later on. */}}
   {{- if .CurrentSection -}}
-    {{- $list_page := .Site.GetPage "page" (printf "%s%s" .CurrentSection.Dir "_index") -}}
+    {{- $list_page := .Site.GetPage "page" (printf "%s%s" .CurrentSection.File.Dir "_index") -}}
     {{/* real_page is the _index.md file which indicates the page that is
       calling this list.html layout. We need this file to find the path of the
       page more easily. page indicates the _index headless page in this layout

--- a/layouts/partials/fragments/editor.html
+++ b/layouts/partials/fragments/editor.html
@@ -8,8 +8,8 @@
 {{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}
 <script>
   (window.editors || (window.editors = [])).push({
-    ui: JSON.parse({{ readFile (printf "%s%s/ui.json" .page.Dir .Name) | safeHTML }}),
-    schema: JSON.parse({{ readFile (printf "%s%s/schema.json" .page.Dir .Name) | safeHTML }}),
+    ui: JSON.parse({{ readFile (printf "%s%s/ui.json" .page.File.Dir .Name) | safeHTML }}),
+    schema: JSON.parse({{ readFile (printf "%s%s/schema.json" .page.File.Dir .Name) | safeHTML }}),
     container: {{ printf "#%s [data-portal]" .Name }}
   });
 </script>

--- a/layouts/partials/fragments/graph.html
+++ b/layouts/partials/fragments/graph.html
@@ -15,6 +15,6 @@
   var fragmentName = "{{ .Name }}";
   window.syna.api.register('graph', 'graph-' + fragmentName, {
     selector: "{{ printf "#chart-%s" .Name }}",
-    config: JSON.parse({{ readFile (printf "%s%s/config.json" .page.Dir .Name) | safeHTML }}),
+    config: JSON.parse({{ readFile (printf "%s%s/config.json" .page.File.Dir .Name) | safeHTML }}),
   });
 </script>

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -94,7 +94,7 @@
 </header>
 <script>
   var fragmentName = "{{ .Name }}";
-  {{- $file_path := printf "%s%s/config.json" .page.Dir .Name -}}
+  {{- $file_path := printf "%s%s/config.json" .page.File.Dir .Name -}}
   window.syna.api.register("hero", "hero-" + fragmentName, {
     selector: "{{ printf "%s-particles-js" .Name }}",
     config: {{ if fileExists $file_path -}} JSON.parse({{ readFile $file_path | safeHTML }}) {{- else -}} null {{- end -}},

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -45,7 +45,7 @@
   {{- end }}
   {{ with .Site.Params.name -}}<meta name="author" content="{{ . }}">{{- end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <title>
     {{- $title | safeHTML -}}

--- a/layouts/partials/helpers/config.html
+++ b/layouts/partials/helpers/config.html
@@ -8,7 +8,7 @@
   {{- else if and (ne .data.resource "") (in (slice "css" "icon" "js") .type) -}}
     {{- $.root.Scratch.Set "config_resource" .data.resource -}}
     {{- if not (or (hasPrefix .data.resource "http://") (hasPrefix .data.resource "https://")) -}}
-      {{- $page_level_resource := printf "%s%s" $.root.Dir .data.resource -}}
+      {{- $page_level_resource := printf "%s%s" $.root.File.Dir .data.resource -}}
       {{- if fileExists (printf "content/%s" $page_level_resource) -}}
         {{- $.root.Scratch.Set "config_resource" $page_level_resource -}}
       {{- end -}}

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -85,7 +85,7 @@
     case to find the root directory. $real_page is added to find the page
     directory as well. */}}
   {{- $page_scratch.Set "sections" (slice "/") -}}
-  {{- $sections := findRE "[^\\/]+" $real_page.CurrentSection.Dir -}}
+  {{- $sections := findRE "[^\\/]+" $real_page.CurrentSection.File.Dir -}}
   {{- range ($sections | default (slice)) -}}
     {{- $page_scratch.Add "sections" . -}}
   {{- end -}}
@@ -101,7 +101,7 @@
       {{- if ne $real_page.Kind "page" -}}
         {{/* Last item is the page being rendered. If it's a section or homepage,
           fragments must be at _index directory */}}
-        {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s%s" $real_page.Dir "_index")) -}}
+        {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s%s" $real_page.File.Dir "_index")) -}}
       {{- else if $page -}}
         {{- $page_scratch.Set "active_page" $page -}}
       {{- end -}}
@@ -151,14 +151,14 @@
 {{- if $page_scratch.Get "fragments" -}}
   {{- range ($page_scratch.Get "fragments") -}}
     {{- $name := replace .Name "/index" "" -}}
-    {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.Dir (replace $name ".md" "")) -}}
+    {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
     {{- if and (not .Params.disabled) (isset .Params "fragment") (not (where ($page_scratch.Get "page_fragments") ".Name" $name)) (not $directory_same_name) -}}
       {{- if or $is_404 (ne .Params.fragment "404") -}}
         {{- if eq .Params.fragment "config" -}}
           {{- $page_scratch.Add "page_config" . -}}
         {{- else -}}
           {{- $page_scratch.Add "page_fragments" . -}}
-          {{- $page_scratch.Add "fragments_directory_name" (printf "%s%s/" $root.Dir (replace $name ".md" "")) -}}
+          {{- $page_scratch.Add "fragments_directory_name" (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
           {{- if isset .Params "padding" -}}
             {{- $page_scratch.Add "experimentals_used_messages" "FrontMatter variable 'padding' is experimental and may get removed without notice" -}}
           {{- end -}}

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -5,7 +5,7 @@
 
 {{/* Page specific resource */}}
 {{- if .root.page -}}
-  {{- $location := (printf "%s/%s" .root.page.Dir $image) -}}
+  {{- $location := (printf "%s/%s" .root.page.File.Dir $image) -}}
   {{- if (fileExists (printf "content/%s" $location)) -}}
     {{- .root.page_scratch.Set "image" $location -}}
   {{- end -}}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -8,7 +8,7 @@
 {{- end -}}
 
 {{- $.Scratch.Set "loaded_scripts" slice -}}
-{{- range uniq ($.Scratch.Get "js") -}}
+{{- range ($.Scratch.Get "js") -}}
   {{- if or (and .name (not (in ($.Scratch.Get "loaded_scripts") .name))) (not (isset . "name")) -}}
     {{- if .url -}}
       <script 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove `uniq` function where it was comparing an array containing different values
- Fix `.Dir` depreciation warning
- Fix `.Hugo` depreciation warning

**Which issue this PR fixes**:
fixes #562 

**Special notes for your reviewer**:
There is another deprecation warning that is not affecting the build. It's related to `Page.URL` variable. Fixing it is a bit problematic since for example contact fragment:139:76 would function differently if we change it. I think we should discuss that fix in another issue.