### PR TITLE
Add support for sort order in the list fragment

### DIFF
--- a/exampleSite/content/dev/_index/list.md
+++ b/exampleSite/content/dev/_index/list.md
@@ -5,4 +5,7 @@ weight = 100
 subsections = true
 count = 100
 summary = false
+
+sort = "Weight"
+sort_order = "asc"
 +++

--- a/exampleSite/content/fragments/list/docs.md
+++ b/exampleSite/content/fragments/list/docs.md
@@ -29,6 +29,20 @@ This value will be used for finding pages. The value by default is the path to t
 
 If set to `true`, it will show the summary of the page. It works by looking for a Content fragment in the page and fetching the summary, either by looking for a `summary` variable in that Content fragment or by using Hugo to summarize the content.
 
+#### sort
+*type: string*
+*accepted values: All Hugo [page variables](https://gohugo.io/variables/page/)*
+*default: PublishDate*
+
+Sets the sort property. Accepted values are all the public fields on the page variable. Please refer to [*Page variables*](https://gohugo.io/variables/page/) documentation page on Hugo.
+
+#### sort_order
+*type: string*
+*accepted values: asc, desc*
+*default: asc*
+
+Sets the sort order.
+
 #### images
 *type: boolean*  
 *default: true*

--- a/exampleSite/content/fragments/list/list.md
+++ b/exampleSite/content/fragments/list/list.md
@@ -16,6 +16,9 @@ section = "dev/blog" # Default value is current section
 display_date = true # Default is false
 #collapsible = true # Default value is false
 
+#sort = "Title" # Default is PublishDate
+#sort_order = "asc" # Default is asc
+
 #subsections = true # Default to true. Shows subsection branch pages
 #subsection_leaves = true # Default to false. Shows subsection leaf pages
 +++

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -34,7 +34,7 @@
   <div class="row mx-0
     {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}
   ">
-    {{- range first (.Params.count | default 10) (.page_scratch.Get "pages") -}}
+    {{- range first (.Params.count | default 10) (sort (.page_scratch.Get "pages") (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
       {{- $page := . -}}
       {{- $self.page_scratch.Set "article_page_fragments" (slice .) -}}
       {{- range .Resources.ByType "page" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for two new variables in the list fragment: `sort`, `sort_order`. These two variables change the sort variable and order for the list fragment. It wasn't possible to use `ByTitle` or other variables that Hugo exposes on the page collection since we collect pages and combine them with sections.

**Which issue this PR fixes**:
fixes #583 

**Special notes for your reviewer**:

**Release note**:
```release-note
List: Add `sort` and `sort_order` variables
```
