### PR TITLE
Fix fragments not showing in the 404 page

### DIFF
--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -151,7 +151,7 @@
 {{- if $page_scratch.Get "fragments" -}}
   {{- range ($page_scratch.Get "fragments") -}}
     {{- $name := replace .Name "/index" "" -}}
-    {{- if $root.File -}}
+    {{- if ne $root.File nil -}}
       {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
       {{- if and (not .Params.disabled) (isset .Params "fragment") (not (where ($page_scratch.Get "page_fragments") ".Name" $name)) (not $directory_same_name) -}}
         {{- if or $is_404 (ne .Params.fragment "404") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix 404 page not displaying it's fragments. It was a null check.

**Which issue this PR fixes**:
fixes #575

**Special notes for your reviewer**:

**Release note**:
```release-note
- 404 page: Fragments were not being shown due to a change in Go template conditionals
```
