### PR TITLE
Fix global fragments with subitems showing warning

### DIFF
--- a/layouts/partials/fragments/faq.html
+++ b/layouts/partials/fragments/faq.html
@@ -1,7 +1,8 @@
+{{- $items := partial "helpers/subitems.html" . -}}
+
 {{- $self := .self -}}
 {{- $bg := .Params.background | default "white" -}}
 {{- .page_scratch.Add "js" (dict "file" "syna-collapse.js") -}}
-{{- $items := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" $self.Name -}}
 
 {{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -1,4 +1,5 @@
-{{- $items := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
+{{- $items := partial "helpers/subitems.html" . -}}
+
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
@@ -11,7 +12,8 @@
       {{- range $items -}}
         {{/* Handle special case of index.md being considered an item */}}
         {{- if not (in .Name "/index.md") -}}
-          {{- $item := .Params }}
+          {{- $item := .Params -}}
+          {{- $this := . }}
           <div class="col-md-4 d-flex flex-column">
             {{- if and $item.asset $item.asset.url }}
               <a href="{{ $item.asset.url | relLangURL }}" class="col justify-content-between d-flex flex-column header
@@ -23,7 +25,7 @@
               <div class="row image justify-content-center align-items-center">
                 {{- with $item.asset -}}
                   {{- if .image }}
-                    <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" . "resize" "300x110") }}" class="p-2 w-75 mb-2" alt="{{ .text | default $item.title }}">
+                    <img src="{{ partial "helpers/image.html" (dict "root" $self "this" $this "asset" . "resize" "300x110") }}" class="p-2 w-75 mb-2" alt="{{ .text | default $item.title }}">
                   {{- else if .icon }}
                     <span class="fa-stack fa-3x m-2" title="{{ .text | default $item.title }}">
                       <i class="fas fa-circle fa-stack-2x

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -1,21 +1,22 @@
+{{- $items := partial "helpers/subitems.html" . -}}
+
 {{- $self := . -}}
-{{- $members := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
 {{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
-  {{- if eq (len $members) 0 -}}
+  {{- if eq (len $items) 0 -}}
     {{- partial "helpers/empty-subpath.html" (dict "context" "member" "root" $) -}}
-  {{- else if gt $members 1 -}}
+  {{- else if gt $items 1 -}}
     <div class="row justify-content-center align-items-start">
-      {{- range $members -}}
+      {{- range $items -}}
         {{/* Handle special case of index.md being considered a member */}}
         {{- if not (in .Name "/index.md") -}}
           {{- $member := .Params -}}
           <div class="col-lg-4 col-md-6 col-sm-12 pt-3 pb-5 text-left text-sm-center">
             {{- if .Params.asset -}}
               <div class="text-center m-2">
-                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset "resize" "250x250") }}" class="img-fluid rounded-circle w-75 border
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "this" . "asset" .Params.asset "resize" "250x250") }}" class="img-fluid rounded-circle w-75 border
                   {{- if or (eq $bg "white") (eq $bg "light") (eq $bg "secondary") (eq $bg "primary") -}}
                     {{- print " border-dark" -}}
                   {{- else -}}
@@ -87,9 +88,9 @@
         {{- end -}}
       {{- end }}
     </div>
-  {{- else if le $members 1 -}}
+  {{- else if le $items 1 -}}
     <div class="card p-2">
-      {{- range $members -}}
+      {{- range $items -}}
         <div class="row m-0 justify-content-center 
           {{- if .Params.asset -}}
             {{- printf " align-items-center" -}}
@@ -99,7 +100,7 @@
             {{- $member := .Params -}}
             {{- if .Params.asset -}}
               <div class="col-12 col-lg-5 p-5 text-center">
-                <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset "resize" "250x250") }}" class="img-fluid rounded-circle border
+                <img src="{{ partial "helpers/image.html" (dict "root" $self "this" . "asset" .Params.asset "resize" "250x250") }}" class="img-fluid rounded-circle border
                   {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "white") -}}
                 " alt="{{ $member.title }}"></img>
               </div>

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -1,5 +1,6 @@
+{{- $items := partial "helpers/subitems.html" . -}}
+
 {{- $self := . -}}
-{{- $items := where (.page.Resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
 {{- .page_scratch.Add "js" (dict "file" "syna-portfolio.js") -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
@@ -22,7 +23,7 @@
               <a href="{{ .Params.item_url | relLangURL }}">
             {{- end }}
                 {{- if .Params.asset -}}
-                  <img src="{{ partial "helpers/image.html" (dict "root" $self "asset" .Params.asset "resize" "500x380") }}" class="img-fluid" alt="{{ .Params.asset.text }}">
+                  <img src="{{ partial "helpers/image.html" (dict "root" $self "this" . "asset" .Params.asset "resize" "500x380") }}" class="img-fluid" alt="{{ .Params.asset.text }}">
                 {{- end }}
                 <div class="position-absolute hover-overlay"></div>
                 {{- if .Params.labels -}}

--- a/layouts/partials/fragments/pricing.html
+++ b/layouts/partials/fragments/pricing.html
@@ -1,5 +1,6 @@
+{{- $items := partial "helpers/subitems.html" . -}}
+
 {{- .page_scratch.Add "js" (dict "file" "syna-pricing.js") -}}
-{{- $items := where (.resources.Match (printf "%s/*.md" .Name)) ".Name" "ne" .self.Name -}}
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -119,7 +119,9 @@
   {{- end -}}
 
   {{- range sort ($page_scratch.Get "fragment_directories_tmp") "index" "desc" -}}
-    {{- $page_scratch.Add "fragment_directories" .directory -}}
+    {{ if .directory }}
+      {{- $page_scratch.Add "fragment_directories" .directory -}}
+    {{ end }}
   {{- end -}}
 {{- end -}}
 
@@ -128,15 +130,13 @@
   the fragments in those directories. We will remove the duplicates later. */}}
 {{- $page_scratch.Set "fragments" (slice) -}}
 {{- range $directory := ($page_scratch.Get "fragment_directories") -}}
-  {{- if $directory -}}
-    {{/* Every index.md or [page].md file can be a fragment as well. Even in
-      _index directories. */}}
+  {{/* Every index.md or [page].md file can be a fragment as well. Even in
+    _index directories. */}}
+  {{- $page_scratch.Add "fragments" . -}}
+  {{/* Fragments are just page resources with type page (generally any .md
+    file) */}}
+  {{- range ($directory.Resources.ByType "page") -}}
     {{- $page_scratch.Add "fragments" . -}}
-    {{/* Fragments are just page resources with type page (generally any .md 
-      file) */}}
-    {{- range ($directory.Resources.ByType "page") -}}
-      {{- $page_scratch.Add "fragments" . -}}
-    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -1,3 +1,10 @@
+{{- $page := .root.page -}}
+{{- $fragment_path := .root.file_path -}}
+
+{{- if ne .this nil -}}
+  {{- $page = .root.Site.GetPage "page" (printf "/%s" (path.Dir (path.Dir .this.File.Dir))) -}}
+  {{- $fragment_path = strings.TrimSuffix ".md" (replace (path.Dir .this.File.Path) "/index.md" "") -}}
+{{- end -}}
 {{/* Global resource fallback */}}
 {{- $image := .asset.image -}}
 
@@ -12,17 +19,17 @@
 {{- .root.page_scratch.Set "image" (printf "images/%s" $image) -}}
 
 {{/* Page specific resource */}}
-{{- if .root.page -}}
-  {{- $location := (printf "%s/%s" .root.page.File.Dir $image) -}}
+{{- if $page -}}
+  {{- $location := (printf "%s/%s" $page.File.Dir $image) -}}
   {{- if (fileExists (printf "content/%s" $location)) -}}
-    {{- .root.page_scratch.Set "resource" (.root.page.Resources.GetMatch $image) -}}
+    {{- .root.page_scratch.Set "resource" ($page.Resources.GetMatch $image) -}}
   {{- end -}}
 {{- end -}}
 
 {{/* Fragment specific resource */}}
-{{- $location := (printf "%s/%s" .root.file_path $image) -}}
+{{- $location := (printf "%s/%s" $fragment_path $image) -}}
 {{- if (fileExists (printf "content/%s" $location)) -}}
-  {{- .root.page_scratch.Set "resource" (.root.page.Resources.GetMatch (strings.TrimPrefix .root.page.File.Dir $location)) -}}
+  {{- .root.page_scratch.Set "resource" ($page.Resources.GetMatch (strings.TrimPrefix $page.File.Dir $location)) -}}
 {{- end -}}
 
 {{- if eq (.root.page_scratch.Get "resource") nil -}}

--- a/layouts/partials/helpers/subitems.html
+++ b/layouts/partials/helpers/subitems.html
@@ -1,0 +1,16 @@
+{{- $page := .page -}}
+{{- $self := .self -}}
+{{- $name := .Name -}}
+{{- $site := .Site -}}
+{{- $page_scratch := .page_scratch -}}
+{{- $items := where ($page.Resources.Match (printf "%s/*.md" $name)) ".Name" "ne" $self.Name -}}
+
+{{- if eq (len $items) 0 -}}
+  {{- range $directory := ($page_scratch.Get "fragment_directories") -}}
+    {{- if eq (len $items) 0 -}}
+      {{- $items = where ($directory.Resources.Match (printf "%s/*.md" $name)) ".Name" "ne" $self.Name -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $items -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Global fragments with subitems (member, items, portfolio, faq) now display their subitems instead of "empty subitems" warning.

**Which issue this PR fixes**:
fixes #582 

**Release note**:
```release-note
- Fixed global fragments with subitems showing warning instead of items
```
