### PR TITLE
Fix toc list displaying pagination in docs

### DIFF
--- a/exampleSite/content/docs/_global/sidebar.md
+++ b/exampleSite/content/docs/_global/sidebar.md
@@ -9,4 +9,5 @@ display_categories = false
 display_date = false
 summary = false
 collapsible = true
+count = 100
 +++


### PR DESCRIPTION
**What this PR does / why we need it**:
Toc was displaying pagination in the sidebar of the docs pages.

