### PR TITLE
Fix children deptch in toc

### DIFF
--- a/layouts/partials/fragments/toc.html
+++ b/layouts/partials/fragments/toc.html
@@ -53,13 +53,7 @@
 {{- if ne (.page_scratch.Get "content_page") "" -}}
   {{- $bg := .self.Scratch.Get "bg" }}
   {{- $toc := (.page_scratch.Get "content_page").TableOfContents -}}
-  {{/* Remove empty lists and list items */}}
-  {{- $toc := (replace $toc "<ul>\n<li>\n<ul>" "<ul>") -}}
-  {{- $toc := (replace $toc "<ul>\n<li>\n<ul>" "<ul>") -}}
-  {{- $toc := (replace $toc "<ul>\n<li>\n<ul>" "<ul>") -}}
-  {{- $toc := (replace $toc "</ul></li>\n</ul>" "</ul>") -}}
-  {{- $toc := (replace $toc "</ul></li>\n</ul>" "</ul>") -}}
-  {{- $toc := (replace $toc "</ul></li>\n</ul>" "</ul>") -}}
+  {{/* Change urls and make them absolute */}}
   {{- $toc := (replace $toc "<li><a href=\"" (printf "<li><a href=\"%s" (.page_scratch.Get "url"))) -}}
   {{/* count the number of remaining li tags and only display ToC if more than
     1, otherwise why bother */}}


### PR DESCRIPTION
**What this PR does / why we need it**:
ToC did not display items in correct depth.

**Which issue this PR fixes**:
fixes #596 

**Special notes for your reviewer**:
This fix includes removing the code responsible for removing the empty children. I tested the result with various scenarios and didn't find any issues. Please keep this in mind if the issue rises in the future.

**Release note**:
```release-note
- toc: Fix children depth
```
