### PR TITLE
Filter special pages out of list fragment's displayed pages

### DIFF
--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -28,13 +28,17 @@
   {{- .page_scratch.Set "pages" $paginator.Pages -}}
   {{- .page_scratch.Set "paginator" $paginator -}}
 {{- end -}}
+
+{{- $filtered_pages := (partial "helpers/filter-special-pages.html" (dict "pages" (.page_scratch.Get "pages") "page_scratch" .page_scratch)) -}}
+{{- $sorted_pages := (sort $filtered_pages (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
+
 {{- $bg := .self.Scratch.Get "bg" }}
 {{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   <div class="row mx-0
     {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}
   ">
-    {{- range first (.Params.count | default 10) (sort (.page_scratch.Get "pages") (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
+    {{- range first (.Params.count | default 10) $sorted_pages -}}
       {{- $page := . -}}
       {{- $self.page_scratch.Set "article_page_fragments" (slice .) -}}
       {{- range .Resources.ByType "page" -}}

--- a/layouts/partials/helpers/filter-special-pages.html
+++ b/layouts/partials/helpers/filter-special-pages.html
@@ -1,0 +1,7 @@
+{{ .page_scratch.Set "tmp_pages" slice }}
+{{ range .pages }}
+  {{ if not (or (strings.HasSuffix .File.Dir "/_index/") (strings.HasSuffix .File.Dir "/_global/")) }}
+    {{ $.page_scratch.Add "tmp_pages" . }}
+  {{ end }}
+{{ end }}
+{{ return .page_scratch.Get "tmp_pages" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
List fragment listed special pages (_global and _index). Seems like we have to do everything in our own code. Including filtering headless pages which should not be listed anyways. At least when `.Paginate` is called.

**Which issue this PR fixes**:
fixes #595 

**Release note**:
```release-note
- list: Remove special pages from fragment. The bug occurs in Hugo>=0.57
```
