### PR TITLE
Fix missing space before height and width attributes in asset img tag

### DIFF
--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -43,8 +43,8 @@
               {{- print $.Params.title -}}
             {{- end -}}
           "
-          {{- if .height -}} height="{{ .height }}"{{- end -}}
-          {{- if .width -}} width="{{ .width }}"{{- end -}}
+          {{- if .height }} height="{{ .height }}"{{- end -}}
+          {{- if .width }} width="{{ .width }}"{{- end -}}
         ></img>
       </div>
     {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The hero fragment allows a user to include an asset in the hero banner. However, the HTML for the img tag is broken if width and/or height is set:

    <img
          class="overlay img-fluid"
          src="/images/logo.svg"
          alt="logo"width="500px"></img>

Notice missing space before width. This PR fixes this.

**Release note**:
```
Hero fragment: Added missing space before height/width attributes in <img> tag
```
