### PR TITLE
Add container to content fragment

### DIFF
--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -1,71 +1,64 @@
 {{- $self := .self -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{ "<!-- Content -->" | safeHTML }}
-<section id="{{ .Name }}" class="content-fragment fragment">
-  <div class="overlay container-fluid
-    {{- printf " bg-%s" $bg -}}
-  ">
-    <div class="container py-5">
-      <div class="row">
-        {{- with .Params.sidebar -}}
-          <div class="content-sidebar col-md-3 pb-4 px-md-0 {{- if (eq .align "right") }} order-1 {{- else }} order-0 {{- end -}}">
-            {{- if .sticky }}
-              <div class="sticky-top pt-3">
-            {{- end -}}
-            {{- if .title }}
-              <div class="col-12 px-0
-                {{- partial "helpers/text-color.html" (dict "self" $self) -}}
-              ">
-                {{- $title_align := .title_align | default "left" -}}
-                <h3 class="sidebar-title {{- printf " text-%s" $title_align -}}">
-                  {{- .title | markdownify -}}
-                </h3>
-              </div>
-            {{- end }}
-            {{- $content_align := .content_align | default "left" -}}
-            <div class="col-12 px-0
-              {{- printf " text-%s" $content_align -}}
-              {{- partial "helpers/text-color.html" (dict "self" $self "light" "secondary") -}}
-            ">
-              {{- .content | markdownify -}}
-              {{ partial "helpers/slot.html" (dict "root" $ "slot" "sidebar" "data" (dict "page" $.page "content_fragment" $self)) }}
-            </div>
-            {{- if .sticky }}
-              </div> {{/* .sticky-top */}}
-            {{- end -}}
-          </div>
-          <article class="col-md-9">
-        {{- else }}
-          <article class="col-md-12">
-        {{- end }}
-          {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
-          {{- if or .Params.display_date .Params.categories -}}
-            <div class="col-12 pb-4 mt-2">
-              {{- if .Params.display_date -}}
-                {{- partial "helpers/publish-date.html" (dict "root" $self "background" $bg) -}}
-              {{- end -}}
-              {{- with .Params.categories }}
-                {{- partial "helpers/categories.html" (dict "categories" . "background" $bg) -}}
-              {{- end }}
-            </div>
-          {{- end }}
-          {{- if .Params.asset -}}
-            <div class="col-12">
-              <img src="{{ partial "helpers/image.html" (dict "root" . "asset" .Params.asset) }}" alt="{{ .Params.subtitle | default .Params.title }}" class="img-fluid mb-4">
-            </div>
-          {{- end -}}
-          <div class="col-12 content px-0
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params "section_class" "content-fragment" "container_class" "overlay") -}}
+  <div class="row">
+    {{- with .Params.sidebar -}}
+      <div class="content-sidebar col-md-3 pb-4 px-md-0 {{- if (eq .align "right") }} order-1 {{- else }} order-0 {{- end -}}">
+        {{- if .sticky }}
+          <div class="sticky-top pt-3">
+        {{- end -}}
+        {{- if .title }}
+          <div class="col-12 px-0
             {{- partial "helpers/text-color.html" (dict "self" $self) -}}
           ">
-            {{- partial "helpers/slot.html" (dict "root" $ "slot" "before-content" "data" (dict "page" $.page "content_fragment" .self)) -}}
-            {{- $content := $self.Content | markdownify -}}
-            {{- $content := replace $content "<blockquote>" "<blockquote class=\"blockquote\">" -}}
-            {{- $content | safeHTML -}}
-            {{- partial "helpers/slot.html" (dict "root" $ "slot" "after-content" "data" (dict "page" $.page "content_fragment" .self)) -}}
+            {{- $title_align := .title_align | default "left" -}}
+            <h3 class="sidebar-title {{- printf " text-%s" $title_align -}}">
+              {{- .title | markdownify -}}
+            </h3>
           </div>
-        </article>
+        {{- end }}
+        {{- $content_align := .content_align | default "left" -}}
+        <div class="col-12 px-0
+          {{- printf " text-%s" $content_align -}}
+          {{- partial "helpers/text-color.html" (dict "self" $self "light" "secondary") -}}
+        ">
+          {{- .content | markdownify -}}
+          {{ partial "helpers/slot.html" (dict "root" $ "slot" "sidebar" "data" (dict "page" $.page "content_fragment" $self)) }}
+        </div>
+        {{- if .sticky }}
+          </div> {{/* .sticky-top */}}
+        {{- end -}}
       </div>
-    </div>
+      <article class="col-md-9">
+    {{- else }}
+      <article class="col-md-12">
+    {{- end }}
+      {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
+      {{- if or .Params.display_date .Params.categories -}}
+        <div class="col-12 pb-4 mt-2">
+          {{- if .Params.display_date -}}
+            {{- partial "helpers/publish-date.html" (dict "root" $self "background" $bg) -}}
+          {{- end -}}
+          {{- with .Params.categories }}
+            {{- partial "helpers/categories.html" (dict "categories" . "background" $bg) -}}
+          {{- end }}
+        </div>
+      {{- end }}
+      {{- if .Params.asset -}}
+        <div class="col-12">
+          <img src="{{ partial "helpers/image.html" (dict "root" . "asset" .Params.asset) }}" alt="{{ .Params.subtitle | default .Params.title }}" class="img-fluid mb-4">
+        </div>
+      {{- end -}}
+      <div class="col-12 content px-0
+        {{- partial "helpers/text-color.html" (dict "self" $self) -}}
+      ">
+        {{- partial "helpers/slot.html" (dict "root" $ "slot" "before-content" "data" (dict "page" $.page "content_fragment" .self)) -}}
+        {{- $content := $self.Content | markdownify -}}
+        {{- $content := replace $content "<blockquote>" "<blockquote class=\"blockquote\">" -}}
+        {{- $content | safeHTML -}}
+        {{- partial "helpers/slot.html" (dict "root" $ "slot" "after-content" "data" (dict "page" $.page "content_fragment" .self)) -}}
+      </div>
+    </article>
   </div>
-</section>
+{{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}

--- a/layouts/partials/helpers/container.html
+++ b/layouts/partials/helpers/container.html
@@ -2,13 +2,11 @@
 {{ (printf "<!-- %s -->" (humanize .Params.fragment)) | safeHTML }}
 {{- end }}
 {{- if .start }}
-<section id="{{ .Name }}" class="fragment">
+<section id="{{ .Name }}" class="{{- printf "fragment %s" .section_class -}}">
   {{- if ne .in_slot true }}
-    <div class="container-fluid
-      {{- printf " bg-%s" .bg -}}
-    ">
+    <div class="{{- printf "container-fluid bg-%s %s" .bg .container_class -}}">
   {{- end }}
-    <div class="container {{ print (.Params.padding | default (cond (eq .in_slot true) "p-0" "py-5")) -}}">
+    <div class="container {{ print (.Params.padding | default (cond (eq .in_slot true) "p-0" "py-5")) -}} {{- printf " %s" .container_class -}}">
 {{- end -}}
 {{- if .end }}
     </div>{{/* .container */}}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #621 

**Release note**:
```release-note
- content: Content fragment now supports `padding` variable like other fragments, making use of our container helper
```
