### PR TITLE
Extract list-pages helper from list fragment

### DIFF
--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -1,36 +1,9 @@
 {{- $self := . -}}
 {{- .page_scratch.Add "js" (dict "file" "syna-collapse.js") -}}
 
-{{/* Sets page to either the given frontmatter section variable, current
-  parent section or if the current page is a section, the current page */}}
-{{- .page_scratch.Set "page" (.Site.GetPage "Section" (.Params.section | default .root.Section)) -}}
-{{- if .root.CurrentSection -}}
-  {{- if and (not .Params.section) (eq .root.CurrentSection.Kind "section") -}}
-    {{- .page_scratch.Set "page" .root.CurrentSection -}}
-  {{- end -}}
-{{- end -}}
-
-{{- .page_scratch.Set "pages" (.page_scratch.Get "page").Pages -}}
-{{- if .Params.subsections -}}
-  {{- .page_scratch.Add "pages" (.page_scratch.Get "page").Sections -}}
-{{- end -}}
-{{- if .Params.subsection_leaves -}}
-  {{- range (.page_scratch.Get "page").Sections -}}
-    {{- $self.page_scratch.Add "pages" .Pages -}}
-  {{- end -}}
-{{- end -}}
-
-{{/* Pagination is used if paginate (default value is 10) is more than
-  frontmatter count variable */}}
-{{- $renderPagination := and (in (slice "section" "home") .root.Kind) (or (not (isset .Params "count")) (le .Params.count 0)) -}}
-{{- if $renderPagination -}}
-  {{- $paginator := .root.Paginate ($self.page_scratch.Get "pages") -}}
-  {{- .page_scratch.Set "pages" $paginator.Pages -}}
-  {{- .page_scratch.Set "paginator" $paginator -}}
-{{- end -}}
-
-{{- $filtered_pages := (partial "helpers/filter-special-pages.html" (dict "pages" (.page_scratch.Get "pages") "page_scratch" .page_scratch)) -}}
-{{- $sorted_pages := (sort $filtered_pages (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
+{{- $list_pages := partial "helpers/list-pages.html" (dict "Site" .Site "Params" .Params "root" .root "page_scratch" .page_scratch) -}}
+{{- $render_pagination := $list_pages.render_pagination -}}
+{{- $sorted_pages := $list_pages.sorted_pages -}}
 
 {{- $bg := .self.Scratch.Get "bg" }}
 {{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
@@ -180,7 +153,7 @@
       {{- end -}}
     {{- end }}
   </div>
-  {{- if $renderPagination -}}
+  {{- if $render_pagination -}}
     {{- partial "helpers/pagination.html" (dict "paginator" .root.Paginator "page_scratch" .page_scratch) -}}
   {{- end }}
 {{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}

--- a/layouts/partials/helpers/list-pages.html
+++ b/layouts/partials/helpers/list-pages.html
@@ -1,0 +1,32 @@
+{{/* Sets page to either the given frontmatter section variable, current
+  parent section or if the current page is a section, the current page */}}
+{{- .page_scratch.Set "page" (.Site.GetPage "Section" (.Params.section | default .root.Section)) -}}
+{{- if .root.CurrentSection -}}
+  {{- if and (not .Params.section) (eq .root.CurrentSection.Kind "section") -}}
+    {{- .page_scratch.Set "page" .root.CurrentSection -}}
+  {{- end -}}
+{{- end -}}
+
+{{- .page_scratch.Set "pages" (.page_scratch.Get "page").Pages -}}
+{{- if .Params.subsections -}}
+  {{- .page_scratch.Add "pages" (.page_scratch.Get "page").Sections -}}
+{{- end -}}
+{{- if .Params.subsection_leaves -}}
+  {{- range (.page_scratch.Get "page").Sections -}}
+    {{- $.page_scratch.Add "pages" .Pages -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Pagination is used if paginate (default value is 10) is more than
+  frontmatter count variable */}}
+{{- $renderPagination := and (in (slice "section" "home") .root.Kind) (or (not (isset .Params "count")) (le .Params.count 0)) -}}
+{{- if $renderPagination -}}
+  {{- $paginator := .root.Paginate ($.page_scratch.Get "pages") -}}
+  {{- .page_scratch.Set "pages" $paginator.Pages -}}
+  {{- .page_scratch.Set "paginator" $paginator -}}
+{{- end -}}
+
+{{- $filtered_pages := (partial "helpers/filter-special-pages.html" (dict "pages" (.page_scratch.Get "pages") "page_scratch" .page_scratch)) -}}
+{{- $sorted_pages := (sort $filtered_pages (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
+
+{{- return (dict "sorted_pages" $sorted_pages "renderPagination" $renderPagination) -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Extracts the new list-pages helper from the list fragment.

**Which issue this PR fixes**:
fixes #623 

**Release note**:
```release-note
- list-pages: A new list-pages helper is available to help create list fragments.
```
