### PR TITLE
Add classes to some of the fragments elements

### DIFF
--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -14,7 +14,7 @@
               <div class="sticky-top pt-3">
             {{- end -}}
             {{- if .title }}
-              <div class="col-12 px-0
+              <div class="content-sidebar-title col-12 px-0
                 {{- partial "helpers/text-color.html" (dict "self" $self) -}}
               ">
                 {{- $title_align := .title_align | default "left" -}}
@@ -24,7 +24,7 @@
               </div>
             {{- end }}
             {{- $content_align := .content_align | default "left" -}}
-            <div class="col-12 px-0
+            <div class="content-sidebar-body col-12 px-0
               {{- printf " text-%s" $content_align -}}
               {{- partial "helpers/text-color.html" (dict "self" $self "light" "secondary") -}}
             ">
@@ -41,7 +41,7 @@
         {{- end }}
           {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
           {{- if or .Params.display_date .Params.categories -}}
-            <div class="col-12 pb-4 mt-2">
+            <div class="content-info col-12 pb-4 mt-2">
               {{- if .Params.display_date -}}
                 {{- partial "helpers/publish-date.html" (dict "root" $self "background" $bg) -}}
               {{- end -}}
@@ -51,11 +51,11 @@
             </div>
           {{- end }}
           {{- if .Params.asset -}}
-            <div class="col-12">
+            <div class="content-image col-12">
               <img src="{{ partial "helpers/image.html" (dict "root" . "asset" .Params.asset) }}" alt="{{ .Params.subtitle | default .Params.title }}" class="img-fluid mb-4">
             </div>
           {{- end -}}
-          <div class="col-12 content px-0
+          <div class="content-body col-12 content px-0
             {{- partial "helpers/text-color.html" (dict "self" $self) -}}
           ">
             {{- partial "helpers/slot.html" (dict "root" $ "slot" "before-content" "data" (dict "page" $.page "content_fragment" .self)) -}}

--- a/layouts/partials/fragments/copyright.html
+++ b/layouts/partials/fragments/copyright.html
@@ -14,14 +14,14 @@
         ">
           <div class="row mx-0 mr-lg-auto justify-content-center">
             {{- with .Params.copyright }}
-              <div class="col-auto">
+              <div class="col-auto copyright-notice">
                 {{- . | markdownify -}}
               </div>
             {{- else }}
-              <div class="col-auto px-1">
+              <div class="col-auto px-1 copyright-legal">
                 {{- i18n "footerLegal.copyright" -}} &nbsp;{{ now.Format "2006" -}}
               </div>
-              <div class="col-auto px-0">
+              <div class="col-auto px-0 copyright-by">
                 {{- printf " %s %s" (i18n "footerLegal.by") $root.Site.Params.name -}}
               </div>
             {{- end }}

--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -26,13 +26,13 @@
     ">
   {{- end }}
   {{- if .Params.particles }}
-    <div id="{{ printf "%s-particles-js" .Name }}" class="particles-js"></div>
+    <div id="{{ printf "%s-particles-js" .Name }}" class="hero-particles particles-js"></div>
   {{- end -}}
   {{- if .Params.asset -}}
     {{- with .Params.asset }}
-      <div class="row justify-content-center align-items-start">
+      <div class="hero-image-container row justify-content-center align-items-start">
         <img
-          class="overlay img-fluid"
+          class="hero-image overlay img-fluid"
           src="{{ partial "helpers/image.html" (dict "root" $self "asset" .) }}"
           alt="
             {{- if .text -}}
@@ -49,8 +49,8 @@
       </div>
     {{- end }}
     {{- with .Params.subtitle }}
-      <div class="row justify-content-center align-items-start">
-        <h1 class="overlay jumbotron-heading my-4
+      <div class="hero-subtitle-container row justify-content-center align-items-start">
+        <h1 class="hero-subtitle overlay jumbotron-heading my-4
           {{- partial "helpers/text-color.html" (dict "self" $self.self) -}}
         ">
           {{- . | markdownify -}}
@@ -59,8 +59,8 @@
     {{- end -}}
   {{- else }}
     {{- if .Params.title_page }}
-      <div class="row justify-content-center align-items-start">
-        <h1 class="overlay jumbotron-heading
+      <div class="hero-page-title-container row justify-content-center align-items-start">
+        <h1 class="hero-page-title overlay jumbotron-heading
           {{- partial "helpers/text-color.html" (dict "self" $self.self) -}}
         ">
           {{ $.root.Title }}
@@ -68,8 +68,8 @@
       </div>
     {{- else -}}
       {{- with .Params.title }}
-        <div class="row justify-content-center align-items-start">
-          <h1 class="overlay jumbotron-heading
+        <div class="hero-title-container row justify-content-center align-items-start">
+          <h1 class="hero-title overlay jumbotron-heading
             {{- partial "helpers/text-color.html" (dict "self" $self.self) -}}
           ">
             {{- . -}}
@@ -78,8 +78,8 @@
       {{- end -}}
     {{- end -}}
     {{- with .Params.subtitle }}
-      <div class="row justify-content-center align-items-start">
-        <div class="overlay lead
+      <div class="hero-subtitle-container row justify-content-center align-items-start">
+        <div class="hero-subtitle overlay lead
           {{- partial "helpers/text-color.html" (dict "self" $self.self) -}}
         ">
           {{- . | markdownify -}}
@@ -87,7 +87,7 @@
       </div>
     {{- end -}}
   {{- end -}}
-  <div>
+  <div class="hero-buttons">
     {{- range .Params.buttons }}
       <a class="overlay btn btn-lg m-2
         {{- if hasPrefix .url " # " }} anchor{{ end -}}

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -151,7 +151,7 @@
   * Render the breadcrumb
   */}}
 {{- if and $display_breadcrumb (lt $level (len ($page_scratch.Get "crumbs"))) }}
-  <nav aria-label="breadcrumb" class="overlay navbar navbar-expand-lg pt-2
+  <nav aria-label="breadcrumb" class="overlay navbar breadcrumb-container navbar-expand-lg pt-2
     {{- printf " bg-%s" $nav_bg -}}
     {{- if or (eq $bg "light") (eq $bg "white") (eq $bg "secondary") -}}
       {{- printf " navbar-%s" "light" -}}

--- a/layouts/partials/helpers/categories.html
+++ b/layouts/partials/helpers/categories.html
@@ -1,5 +1,5 @@
 {{- range .categories }}
-  <div class="badge mr-1 mb-1
+  <div class="categories badge mr-1 mb-1
     {{- if (eq $.background "dark") -}}
       {{- printf " badge-%s" "light" -}}
     {{- else -}}

--- a/layouts/partials/helpers/publish-date.html
+++ b/layouts/partials/helpers/publish-date.html
@@ -1,6 +1,6 @@
 {{- $date := .root.Date | default .root.Lastmod }}
 {{- if not (eq .badge false) }}
-  <span class="badge mr-1
+  <span class="publish-date badge mr-1
     {{- if (eq $.background "dark") -}}
       {{- printf " badge-%s" "light" -}}
     {{- else -}}
@@ -11,7 +11,7 @@
     </time>
   </span>
 {{- else }}
-  <span class="mr-1 badge
+  <span class="publish-data mr-1 badge
     {{- if (eq $.background "dark") -}}
       {{- printf " badge-%s" "light" -}}
     {{- end -}}">

--- a/layouts/partials/helpers/section-header.html
+++ b/layouts/partials/helpers/section-header.html
@@ -2,8 +2,8 @@
 {{- $bg := .bg -}}
 {{- $align := .params.title_align | default "center" -}}
 {{- with .params.title }}
-  <div class="row mx-0">
-    <div class="col px-0
+  <div class="title-container row mx-0">
+    <div class="title col px-0
       {{- printf " text-%s" $align -}}
       {{- partial "helpers/text-color.html" (dict "self" $self) -}}
     ">
@@ -14,8 +14,8 @@
   </div>
 {{- end -}}
 {{- with .params.subtitle -}}
-  <div class="row mx-0">
-    <div class="col pt-4 pb-0 px-0
+  <div class="subtitle-container row mx-0">
+    <div class="subtitle col pt-4 pb-0 px-0
       {{- printf " text-%s" $align -}}
       {{- partial "helpers/text-color.html" (dict "self" $self) -}}
     ">


### PR DESCRIPTION
**What this PR does / why we need it**:
Add classes to some of the fragments' elements

**Which issue this PR fixes**:
fixes #626 

**Release note**:
```release-note
- styling: content, nav, hero, copyright and all fragments' title and subtitle now offer classes for styling
```
