### PR TITLE
add doctype to fix w3c error:

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode | default (printf "en-us") }}">
   {{ block "main" . -}}
     <!-- The part of the page that begins to differ between templates -->


### PR DESCRIPTION
**What this PR does / why we need it**:
Webpages made with Syna don't pass W3C validator, a DOCTYPE is expected at the beginning of the web.
This fix adds the expected html5 declaration so web browsers can work in standards mode.
Most other themes use this declaration.

**Special notes for your reviewer**:
https://validator.w3.org/nu/?doc=https%3A%2F%2Fabout.okkur.org%2F
https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode

**Release note**:
```release-note
Fix: (W3C) Start tag seen without seeing a doctype first
```
