### PR TITLE
Using the meta element to specify the default language is obsolete

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,6 @@
   <meta name="theme-author-url" content="https://about.okkur.org">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta http-equiv="Content-Language" content="{{ .Site.LanguageCode | default "en-us" }}">
   <meta name="google" value="notranslate">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
**What this PR does / why we need it**:
`http-equiv=content-language` is obsolete and deprecated, Syna is already using the new preferred method `<html lang="XX">`

**Special notes for your reviewer**:
[W3 Test validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fabout.okkur.org%2Fsyna)
https://www.w3.org/TR/2011/WD-html-markup-20110113/meta.http-equiv.content-language.html
https://www.w3.org/International/questions/qa-http-and-lang

**Release note**:
```release-note
Improve W3C conformance removing http-equiv="Content-Language"
```
