### PR TITLE
Meta google

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,6 @@
   <meta name="theme-author-url" content="https://about.okkur.org">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta http-equiv="Content-Language" content="{{ .Site.LanguageCode | default "en-us" }}">
   <meta name="google" value="notranslate">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,7 @@
   <meta name="theme-author-url" content="https://about.okkur.org">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="google" value="notranslate">
+  <meta name="google" content="notranslate" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="description" content="{{- .Scratch.Get "page_description" -}}">


### PR DESCRIPTION
**What this PR does / why we need it**:
The `value` attribute should be changed to `content="notranslate"` in order to pass HTML5 validation.

**Special notes for your reviewer**:
https://support.google.com/webmasters/answer/79812?hl=en
https://stackoverflow.com/questions/12238396/how-to-disable-google-translate-from-html-in-chrome

**Release note**:
```release-note
Improve HTML5 conformance 
```
