### PR TITLE
Remove stray end tag div and indent block

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,22 +11,21 @@
 
     <div id="react"></div>
     <div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header row mx-0">
-              <div class="modal-title col px-0">
-                <h5 class="title text-dark"></h5>
-                <h6 class="subtitle text-secondary"></h6>
-              </div>
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header row mx-0">
+            <div class="modal-title col px-0">
+              <h5 class="title text-dark"></h5>
+              <h6 class="subtitle text-secondary"></h6>
             </div>
-            <img src="" alt="" class="img-fluid">
-            <div class="modal-body p-3">
-              <div class="badge-container"></div>
-              <div class="content"></div>
-            </div>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <img src="" alt="" class="img-fluid">
+          <div class="modal-body p-3">
+            <div class="badge-container"></div>
+            <div class="content"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
One less w3 validator's error without the stray div.

**Special notes for your reviewer**:
I don't know exactly what this block of code does, but anyway better to have it clean and tidy.
There is another error with `<img src="" alt="" class="img-fluid">` been empty, but I'm not sure if is there for a especial use case.

**Release note**:
```release-note
Minor fix: remove "tray end tag div" error
```
