### PR TITLE
Fix sort order of list fragment

### DIFF
--- a/layouts/partials/helpers/list-pages.html
+++ b/layouts/partials/helpers/list-pages.html
@@ -27,6 +27,6 @@
 {{- end -}}
 
 {{- $filtered_pages := (partial "helpers/filter-special-pages.html" (dict "pages" (.page_scratch.Get "pages") "page_scratch" .page_scratch)) -}}
-{{- $sorted_pages := (sort $filtered_pages (.Params.sort | default "PublishDate") (.Params.sort_order | default "asc")) -}}
+{{- $sorted_pages := (sort $filtered_pages (.Params.sort | default "PublishDate") (.Params.sort_order | default "desc")) -}}
 
 {{- return (dict "sorted_pages" $sorted_pages "renderPagination" $renderPagination) -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix sort order of list fragment.

**Which issue this PR fixes**:
fixes #663 

**Release note**:
```release-note
- list: Change sort order from ascending to descending.
```
