### PR TITLE
Add default page title

### DIFF
--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -13,6 +13,7 @@
   ">
     {{- range first (.Params.count | default 10) $sorted_pages -}}
       {{- $page := . -}}
+      {{- $page_title := partial "helpers/page-title.html" (dict "page" . "self" .) -}}
       {{- $self.page_scratch.Set "article_page_fragments" (slice .) -}}
       {{- range .Resources.ByType "page" -}}
         {{- $self.page_scratch.Add "article_page_fragments" . -}}
@@ -39,7 +40,7 @@
           {{- if $self.Params.tiled }}
             <div class="card-body">
           {{- end -}}
-            {{- if .Params.title -}}
+            {{- if $page_title -}}
               {{- if $self.Params.tiled }}
                 <div class="card-title">
               {{- end }}
@@ -58,7 +59,7 @@
                         {{- if eq $.page.Permalink .Permalink }} active-page {{- end -}}
                       ">
                         <a href="{{ .Permalink }}">
-                          {{- .Params.title | markdownify -}}
+                          {{- $page_title | markdownify -}}
                         </a>
                       </h4>
                     {{- else }}
@@ -66,7 +67,7 @@
                         {{- if eq $.page.Permalink .Permalink }} active-page {{- end -}}
                       ">
                         <a href="{{ .Permalink }}">
-                          {{- .Params.title | markdownify -}}
+                          {{- $page_title | markdownify -}}
                         </a>
                       </h5>
                     {{- end -}}
@@ -108,7 +109,7 @@
                   ">
                     <img
                       src="{{ partial "helpers/image.html" (dict "root" $root "asset" .Params.asset) }}"
-                      alt="{{ .Params.subtitle | default .Params.title }}"
+                      alt="{{ .Params.subtitle | default $page_title }}"
                       class="img-fluid mb-4">
                   </div>
                 {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,5 @@
-{{- $title := printf "%s%s" .Title (cond (not .IsHome) (printf " &middot; %s" .Site.Title) (print "")) -}}
+{{- $page_title := partial "helpers/page-title.html" (dict "page" . "self" .) -}}
+{{- $title := printf "%s%s" $page_title (cond .IsHome (print "") (printf " &middot; %s" .Site.Title)) -}}
 {{- $content_fragment := first 1 ((where ((.Scratch.Get "page_fragments") | default (slice)) "Params.fragment" "in" "content") | default (slice)) -}}
 {{- .Scratch.Set "page_description" .Site.Params.Description -}}
 {{- range $content_fragment -}}

--- a/layouts/partials/helpers/page-title.html
+++ b/layouts/partials/helpers/page-title.html
@@ -1,0 +1,16 @@
+{{- $page := .page -}}
+{{- $self := .self -}}
+
+{{- $page_title := $page.Title -}}
+{{- if eq $page_title "" -}}
+  {{- $self.Scratch.Set "page_title_page_fragments" (slice .) -}}
+  {{- range $page.Resources.ByType "page" -}}
+    {{- $self.Scratch.Add "page_title_page_fragments" . -}}
+  {{- end -}}
+  {{- $content_page := first 1 (where ($self.Scratch.Get "page_title_page_fragments") "Params.fragment" "in" "content") -}}
+
+  {{- if $content_page -}}
+    {{- $page_title = (index $content_page 0).Title -}}
+  {{- end -}}
+{{- end -}}
+{{- return $page_title -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add default page title using title of the first content fragment found in
page.

**Which issue this PR fixes**:
fixes (partially) #655 

**Special notes for your reviewer**:
This PR only adds default title to the page. Removing date metadata which was mentioned in the issue is not done and I don't think fixing it in the same PR is a good idea since the change is a bit complicated already.

**Release note**:
```release-note
- page: Each page now uses the first content fragment's title as page title by default.
```
