### PR TITLE
languageLang is not in the Hugo documentation, defaultContentLanguage is

### DIFF
--- a/exampleSite/config-dev.toml
+++ b/exampleSite/config-dev.toml
@@ -1,7 +1,7 @@
 # Site settings
 baseurl = "/"
 languageCode = "en-us"
-languageLang = "en"
+defaultContentLanguage = "en"
 title = "Okkur - Syna"
 theme = "syna"
 themesDir = "../.."

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,7 @@
 # Site settings
 baseurl = "/"
 languageCode = "en-us"
-languageLang = "en"
+defaultContentLanguage = "en"
 title = "Okkur - Syna"
 theme = "syna"
 themesDir = "../.."


### PR DESCRIPTION
**What this PR does / why we need it**:
`languageLang` in `exampleSite/config[-dev].toml` seems an obsolete option.

**Special notes for your reviewer**:
I've searched in the [Hugo Docs](https://gohugo.io/getting-started/configuration/#all-configuration-settings) and in the [github's repos](https://github.com/gohugoio) but I dont' find `languageLang` anywhere.
`defaultContentLanguage` is documented and is propably the correct option.

**Release note**:

```release-note
Change languageLang to defaultContentLanguage in config.toml
```
