### PR TITLE
Add basic support for multilingual

### DIFF
--- a/exampleSite/content/docs/deployment/index.md
+++ b/exampleSite/content/docs/deployment/index.md
@@ -1,4 +1,4 @@
 +++
 title = "Deployment"
-weight = 70
+weight = 80
 +++

--- a/exampleSite/content/docs/multilingual/content.md
+++ b/exampleSite/content/docs/multilingual/content.md
@@ -9,9 +9,8 @@ title = "MultiLingual Mode"
 +++
 
 > Syna supports creating Multilingual websites since v0.16.1. The implementation
-> only supports `page[.language code].md` method and not 
-> `[language code]/page.md` but we hope to add the second approach in the 
-> future.
+> currently supports specifying languages on a per file basis such as
+> `page[.language code].md` future.
 
 In order to make your website multilingual, you need to change your
 configuration so Hugo will generate new pages for translated content in your
@@ -23,8 +22,8 @@ same pages but in two languages. Hugo will not however generate English pages
 for German website if those pages are not translated to German. For more 
 information on Hugo's Multilingual mode, please refer to [their documentation](https://gohugo.io/content-management/multilingual/).
 
-In order to configure two languages, you need to udpate your configuration.
-Here's an example from the official documentation:
+In order to configure two languages, you need to update your main your
+configuration. Here's an example from the official documentation:
 
 ```
 DefaultContentLanguage = "en"
@@ -93,7 +92,7 @@ A French version of the page will be generated, containing all your fragments
 but the portfolio fragment will be the translated version. The page will have
 not changed for the default language.
 
-> The Multilingual mode is in alpha mode. This means it is subject to change and
+> Multilingual mode is currently release as alpha. It is subject to changes and
 > may not be stable. Please follow the changelog and updates to this page for
-> more information and news about the changes. Please create issues and pull
+> more information and news about any changes. Please create issues and pull
 > requests and let us know what you think.

--- a/exampleSite/content/docs/multilingual/content.md
+++ b/exampleSite/content/docs/multilingual/content.md
@@ -1,0 +1,99 @@
++++
+fragment = "content"
+weight = 100
+
+title = "MultiLingual Mode"
+
+[sidebar]
+  sticky = true
++++
+
+> Syna supports creating Multilingual websites since v0.16.1. The implementation
+> only supports `page[.language code].md` method and not 
+> `[language code]/page.md` but we hope to add the second approach in the 
+> future.
+
+In order to make your website multilingual, you need to change your
+configuration so Hugo will generate new pages for translated content in your
+project. The way Multilingual mode works is that Hugo generates a new website
+for each language and add each page to the website of the same language. For 
+example if your website has two languages, English and German, and each page
+is translated for both languages, Hugo will generate two websites with 
+same pages but in two languages. Hugo will not however generate English pages
+for German website if those pages are not translated to German. For more 
+information on Hugo's Multilingual mode, please refer to [their documentation](https://gohugo.io/content-management/multilingual/).
+
+In order to configure two languages, you need to udpate your configuration.
+Here's an example from the official documentation:
+
+```
+DefaultContentLanguage = "en"
+
+[languages]
+  [languages.en]
+    title = "My blog"
+    weight = 1
+  [languages.fr]
+    title = "Mon blogue"
+    weight = 2
+
+[params]
+  ...
+```
+
+Please note that these parameters are added outside of `params` variable, inside
+your configuration file (`config.toml`, `config.yaml`, `config.json`). This will
+let Hugo know that there are two languages for this project and the default 
+language is English (`DefaultContentLanguage = "en"`). Since Hugo doesn't 
+expose the default language to the themes, you need to add the parameter to
+`params` as well:
+
+```
+[params]
+  DefaultContentLanguage = "en"
+```
+
+With this, whenever you build your website or start the development server, for
+each translated page you get `example.com/[page]` and `example.com/fr/[page]`.
+
+> Syna can generate pages for both approaches of content management that Hugo
+> supports but currently we only support the "[Translation by filename](https://gohugo.io/content-management/multilingual/#translation-by-filename)"
+> approach. We hope to add support for "[Translation by content directory](https://gohugo.io/content-management/multilingual/#translation-by-content-directory)"
+> in the future.
+
+Syna allows for fragment overrides in translated pages. This means that when you
+translate a page, the translated version will contain all the fragments from the
+default language. This allows for fewer duplicated files in your project. This
+works the same way as "Translation by filename". For example, let's assume we 
+have an `contact` page in our project. The `content` directory might look 
+somthing like this:
+
+```
+contact/index.md
+contact/contact.md
+contact/portfolio.md
+contact/pricing.md
+```
+
+If you want to create a French translation for the `contact` page, and portfolio
+fragment inside that page needs to be translated as well, you need to create a
+copy from `index.md` and `portfolio.md` and name them `index.fr.md` and
+`portfolio.fr.md`, respectively.
+
+```
+contact/index.md
+contact/index.fr.md
+contact/contact.md
+contact/portfolio.md
+contact/portfolio.fr.md
+contact/pricing.md
+```
+
+A French version of the page will be generated, containing all your fragments
+but the portfolio fragment will be the translated version. The page will have
+not changed for the default language.
+
+> The Multilingual mode is in alpha mode. This means it is subject to change and
+> may not be stable. Please follow the changelog and updates to this page for
+> more information and news about the changes. Please create issues and pull
+> requests and let us know what you think.

--- a/exampleSite/content/docs/multilingual/index.md
+++ b/exampleSite/content/docs/multilingual/index.md
@@ -1,0 +1,4 @@
++++
+title = "Multilingual Mode"
+weight = 70
++++

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -76,8 +76,13 @@
 {{- $root := $layout_info.root -}}
 {{- $is_404 := $layout_info.is_404 -}}
 
+{{ $default_lang := $real_page.Site.Params.DefaultContentLanguage }}
+{{ $default_site := index (where $real_page.Sites "Language.Lang" "eq" $default_lang) 0 }}
+{{ $lang := $real_page.Site.Language.Lang }}
+
 {{- $page_scratch.Set "fragment_directories" (slice) -}}
 {{- if eq $is_404 true -}}
+  {{- $page_scratch.Add "fragment_directories" ($default_site.GetPage "page" "/_global") -}}
   {{- $page_scratch.Add "fragment_directories" ($real_page.Site.GetPage "page" "/_global") -}}
 {{- else -}}
   {{/* Lookup the directory of the file, split the path by slashes and find each
@@ -101,20 +106,25 @@
       {{- if ne $real_page.Kind "page" -}}
         {{/* Last item is the page being rendered. If it's a section or homepage,
           fragments must be at _index directory */}}
+        {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s%s" $real_page.File.Dir "_index")) -}}
         {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s%s" $real_page.File.Dir "_index")) -}}
       {{- else if $page -}}
+        {{- $page_scratch.Set "active_page_default" $page -}}
         {{- $page_scratch.Set "active_page" $page -}}
       {{- end -}}
     {{- else if ge $index 1 -}}
       {{/* Sections between the first and last are found and their _global directories
         are taken into account */}}
       {{- $directory := (delimit (first (add $index 1) ($page_scratch.Get "sections")) "/") -}}
+      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
       {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
     {{- else -}}
       {{/* First section is always the root directory and we look for it's _global
         directory */}}
+      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
       {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
     {{- end -}}
+    {{- $page_scratch.Add "fragment_directories_tmp" (dict "directory" ($page_scratch.Get "active_page_default") "index" $index) -}}
     {{- $page_scratch.Add "fragment_directories_tmp" (dict "directory" ($page_scratch.Get "active_page") "index" $index) -}}
   {{- end -}}
 
@@ -129,6 +139,7 @@
   additional _index directory) in the previous loop. Here we will extract all
   the fragments in those directories. We will remove the duplicates later. */}}
 {{- $page_scratch.Set "fragments" (slice) -}}
+{{- $page_scratch.Set "fragments_paths" (slice) -}}
 {{- range $directory := ($page_scratch.Get "fragment_directories") -}}
   {{/* Every index.md or [page].md file can be a fragment as well. Even in
     _index directories. */}}
@@ -136,8 +147,17 @@
   {{/* Fragments are just page resources with type page (generally any .md
     file) */}}
   {{- range ($directory.Resources.ByType "page") -}}
-    {{- $page_scratch.Add "fragments" . -}}
+    {{- $page_scratch.Add "fragments_paths" (dict "path" .File.Path "resource" .) -}}
   {{- end -}}
+{{- end -}}
+
+{{- range ($page_scratch.Get "fragments_paths") -}}
+  {{ $is_resource_single_language := eq (len (where ($page_scratch.Get "fragments_paths") ".path" "eq" (printf "%s%s.%s.md" .resource.File.Dir .resource.File.TranslationBaseName $lang))) 0 }}
+  {{ if and (eq $lang $default_lang) (eq (len (findRE "\\.\\w{2}\\.md" .path)) 0) }}
+    {{- $page_scratch.Add "fragments" .resource -}}
+  {{ else if and (ne $lang $default_lang) (or (eq .resource.File.Lang $lang) $is_resource_single_language) }}
+    {{- $page_scratch.Add "fragments" .resource -}}
+  {{ end }}
 {{- end -}}
 
 {{/* Here we find fragments that are relevant to this page. We do this by

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -76,7 +76,7 @@
 {{- $root := $layout_info.root -}}
 {{- $is_404 := $layout_info.is_404 -}}
 
-{{ $default_lang := $real_page.Site.Params.DefaultContentLanguage }}
+{{ $default_lang := $real_page.Site.Params.DefaultContentLanguage | default $real_page.Site.Language.Lang }}
 {{ $default_site := index (where $real_page.Sites "Language.Lang" "eq" $default_lang) 0 }}
 {{ $lang := $real_page.Site.Language.Lang }}
 
@@ -106,8 +106,9 @@
       {{- if ne $real_page.Kind "page" -}}
         {{/* Last item is the page being rendered. If it's a section or homepage,
           fragments must be at _index directory */}}
-        {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s%s" $real_page.File.Dir "_index")) -}}
-        {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s%s" $real_page.File.Dir "_index")) -}}
+        {{- $page := printf "%s%s" $real_page.File.Dir "_index" -}}
+        {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" $page) -}}
+        {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" $page) -}}
       {{- else if $page -}}
         {{- $page_scratch.Set "active_page_default" $page -}}
         {{- $page_scratch.Set "active_page" $page -}}
@@ -116,13 +117,15 @@
       {{/* Sections between the first and last are found and their _global directories
         are taken into account */}}
       {{- $directory := (delimit (first (add $index 1) ($page_scratch.Get "sections")) "/") -}}
-      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
-      {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
+      {{- $page := printf "%s/%s" $directory "_global" -}}
+      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" $page) -}}
+      {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" $page) -}}
     {{- else -}}
       {{/* First section is always the root directory and we look for it's _global
         directory */}}
-      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
-      {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" (printf "%s/%s" $directory "_global")) -}}
+      {{- $page := printf "%s/%s" $directory "_global" -}}
+      {{- $page_scratch.Set "active_page_default" ($default_site.GetPage "page" $page) -}}
+      {{- $page_scratch.Set "active_page" ($real_page.Site.GetPage "page" $page) -}}
     {{- end -}}
     {{- $page_scratch.Add "fragment_directories_tmp" (dict "directory" ($page_scratch.Get "active_page_default") "index" $index) -}}
     {{- $page_scratch.Add "fragment_directories_tmp" (dict "directory" ($page_scratch.Get "active_page") "index" $index) -}}
@@ -152,12 +155,15 @@
 {{- end -}}
 
 {{- range ($page_scratch.Get "fragments_paths") -}}
-  {{ $is_resource_single_language := eq (len (where ($page_scratch.Get "fragments_paths") ".path" "eq" (printf "%s%s.%s.md" .resource.File.Dir .resource.File.TranslationBaseName $lang))) 0 }}
-  {{ if and (eq $lang $default_lang) (eq (len (findRE "\\.\\w{2}\\.md" .path)) 0) }}
+  {{- $rel_lang_file_name := printf "%s%s.%s.md" .resource.File.Dir .resource.File.TranslationBaseName $lang -}}
+  {{- $rel_lang_file := where ($page_scratch.Get "fragments_paths") ".path" "eq" $rel_lang_file_name -}}
+  {{- $is_resource_single_language := eq (len $rel_lang_file) 0 -}}
+  {{- $is_resource_same_language := eq .resource.File.Lang $lang -}}
+  {{- if and (eq $lang $default_lang) (eq (len (findRE "\\.\\w{2}\\.md" .path)) 0) -}}
     {{- $page_scratch.Add "fragments" .resource -}}
-  {{ else if and (ne $lang $default_lang) (or (eq .resource.File.Lang $lang) $is_resource_single_language) }}
+  {{- else if and (ne $lang $default_lang) (or $is_resource_same_language $is_resource_single_language) -}}
     {{- $page_scratch.Add "fragments" .resource -}}
-  {{ end }}
+  {{- end -}}
 {{- end -}}
 
 {{/* Here we find fragments that are relevant to this page. We do this by

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -36,7 +36,7 @@
   {{- if eq .absolute true -}}
     {{- .root.page_scratch.Get "image" | absURL -}}
   {{- else -}}
-    {{- .root.page_scratch.Get "image" | relLangURL -}}
+    {{- .root.page_scratch.Get "image" | relURL -}}
   {{- end -}}
 {{- else -}}
   {{- if isset . "resize" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds basic support for multilingual websites.

I'll add documentation and examples ASAP.

**Which issue this PR fixes**:
fixes #14
fixes #680 

**Special notes for your reviewer**:

**Release note**:
```release-note
- Syna now supports multilingual websites out of the box
```
