### PR TITLE
WIP: Add support for memberspace

### DIFF
--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -81,6 +81,13 @@
               </a>
             </li>
           {{- end -}}
+        {{- end -}}
+        {{- with ($page_scratch.Get "memberspace") }}
+          <li class="nav-item">
+            <a href="https://{{- .Params.subdomain -}}.memberspace.com/member/sign_in" class="nav-link anchor">
+              Login / Signup
+            </a>
+          </li>
         {{- end }}
       </ul>
       {{- if .Params.search }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -95,4 +95,16 @@
       {{- partial "helpers/config.html" (dict "root" $ "head" true "type" .type "data" .) -}}
     {{- end -}}
   {{- end -}}
+
+  {{- with (.Scratch.Get "memberspace") -}}
+    <script>
+      var MemberSpace = window.MemberSpace || {subdomain: "{{- print .Params.subdomain -}}"};
+      (function(d){
+        var s = d.createElement("script");
+        s.src = "https://cdn.memberspace.com/scripts/widgets.js";
+        var e = d.getElementsByTagName("script")[0];
+        e.parentNode.insertBefore(s,e);
+      }(document));
+    </script>
+  {{- end -}}
 </head>

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -184,7 +184,7 @@
         {{- if or $is_404 (ne .Params.fragment "404") -}}
           {{- if eq .Params.fragment "config" -}}
             {{- $page_scratch.Add "page_config" . -}}
-          {{- else if eq .Params.fragments "memberspace" -}}
+          {{- else if eq .Params.fragment "memberspace" -}}
             {{- $page_scratch.Set "memberspace" . -}}
           {{- else -}}
             {{- $page_scratch.Add "page_fragments" . -}}

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -172,6 +172,7 @@
   looking from the page directory or file to it's parents and so on. */}}
 {{- $page_scratch.Set "page_fragments" (slice) -}}
 {{- $page_scratch.Set "page_config" (slice) -}}
+{{- $page_scratch.Set "memberspace" nil -}}
 {{- $page_scratch.Set "experimentals_used_messages" (slice) -}}
 {{- $page_scratch.Set "fragments_directory_name" (slice) -}}
 {{- if $page_scratch.Get "fragments" -}}
@@ -183,6 +184,8 @@
         {{- if or $is_404 (ne .Params.fragment "404") -}}
           {{- if eq .Params.fragment "config" -}}
             {{- $page_scratch.Add "page_config" . -}}
+          {{- else if eq .Params.fragments "memberspace" -}}
+            {{- $page_scratch.Set "memberspace" . -}}
           {{- else -}}
             {{- $page_scratch.Add "page_fragments" . -}}
             {{- $page_scratch.Add "fragments_directory_name" (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for memberspace

**Which issue this PR fixes**:
fixes #631 

**Special notes for your reviewer**:
The implementation works with a fragment that you can add to _global or any page or section globals and in turn nav fragment in those pages will display a login link. I didn't add anymore customizations since I'm not even sure if this is the best approach. My assumptions is that the user would create a memberspace.md file in _global with following content:

```
+++
fragment = "memberspace"
subdomain = "subdomain_copied_from_installation_guide_of_memberspace"
+++
```

And then the nav fragment will display a link to Login/Signup page in Memberspace. It would be recommended that the button Memberspace provides be disabled from their website. But we can also move the "go to top" button as we discussed.

If you have any other approach in mind please let me know and if everything is okay I can add documentation and we can move forward with the merge.

**Release note**:
```release-note
- memberspace: New fragment that adds memberspace scripts to enable the service for Syna
```
