### PR TITLE
Make use of Hugo internal opengraph template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,11 +18,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="description" content="{{- .Scratch.Get "page_description" -}}">
-  <meta property="og:title" content="{{ $title }}">
-  <meta property="og:url" content="{{ .Permalink }}">
-  <meta property="og:description" content="{{- .Scratch.Get "page_description" -}}">
-  <meta property="og:site_name" content="{{ .Site.Title }}">
-  <meta property="og:type" content="website">
+  {{ template "_internal/opengraph.html" . }}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{{ $title }}" />
   <meta name="twitter:description" content="{{- .Scratch.Get "page_description" -}}">


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously we had hardcorded opengraph meta tags in our
head partial but with the internal opengraph template in
Hugo there's no need for that anymore.

**Which issue this PR fixes**:
fixes #642 

**Release note**:
```release-note
- Make use of [opengraph internal template](https://gohugo.io/templates/internal/#open-graph)
```
