### PR TITLE
Remove particle selector registration when disabled

### DIFF
--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -102,6 +102,7 @@
   </div>
   </div>
 </header>
+{{- if .Params.particles }}
 <script>
   var fragmentName = "{{ .Name }}";
   {{- $file_path := printf "%s%s/config.json" .page.File.Dir .Name -}}
@@ -110,3 +111,4 @@
     config: {{ if fileExists $file_path -}} JSON.parse({{ readFile $file_path | safeHTML }}) {{- else -}} null {{- end -}},
   });
 </script>
+{{ end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously syna api would have kept a reference to particles
canvas even when particles was disabled on the hero element.
This commit fixes that issue and removes useless code.

**Which issue this PR fixes**:
fixes #703 

**Release note**:
```release-note
- hero: Remove extra code when particles is disabled
```
