### PR TITLE
Switch to ubuntu-1604 instead of ubuntu-latest for github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
**What this PR does / why we need it**:
This was causing our tests failing

https://github.com/cypress-io/github-action#important