### PR TITLE
Remove relLangURL from script and favicon links

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,17 +57,17 @@
 
   {{- with .Site.Params.custom -}}
     {{- with .favicon }}
-      <link rel="shortcut icon" type="image/x-icon" href="{{ . | relLangURL }}">
-      <link rel="icon" {{ with $.Site.Params.custom.favicon_ico_sizes }}sizes="{{ . }}"{{ end }} type="image/x-icon" href="{{ . | relLangURL }}">
+      <link rel="shortcut icon" type="image/x-icon" href="{{ . }}">
+      <link rel="icon" {{ with $.Site.Params.custom.favicon_ico_sizes }}sizes="{{ . }}"{{ end }} type="image/x-icon" href="{{ . | relURL }}">
     {{- end }}
 
     {{- with .favicon_png }}
-      <link rel="icon" href="{{ . | relLangURL }}">
-      <link rel="apple-touch-icon-precomposed" href="{{ . | relLangURL }}">
+      <link rel="icon" href="{{ . | relURL }}">
+      <link rel="apple-touch-icon-precomposed" href="{{ . | relURL }}">
     {{- end }}
 
     {{- with .favicon_svg }}
-      <link rel="icon" type="image/svg+xml" href="{{ . | relLangURL }}">
+      <link rel="icon" type="image/svg+xml" href="{{ . | relURL }}">
     {{- end -}}
 
     {{ if and (not .favicon) (not .favicon_png) (not .favicon_svg) }}
@@ -84,7 +84,7 @@
   </script>
   {{- $script_template := resources.Get "scripts/syna-head.js" -}}
   {{- $script := $script_template | resources.Minify | resources.Fingerprint }}
-  <script {{- safeHTMLAttr (printf " src=\"%s\"" ($script.RelPermalink | relLangURL)) -}}></script>
+  <script {{- safeHTMLAttr (printf " src=\"%s\"" ($script.RelPermalink)) -}}></script>
 
   {{- range (.Scratch.Get "page_config") -}}
     {{- range .Params.config -}}

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -29,7 +29,7 @@
         {{- if (.defer | default true) -}}
           {{- safeHTMLAttr (print " defer") -}}
         {{- end -}}
-        {{- safeHTMLAttr (printf " src=\"%s\"" ($script.RelPermalink | relLangURL)) -}}></script>
+        {{- safeHTMLAttr (printf " src=\"%s\"" ($script.RelPermalink)) -}}></script>
     {{- else if .script -}}
       {{ .script | safeHTML }}
     {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
A few static resources are currently generated with a language tag, which prevents them from loading since hugo does not generate localized static assets (afaik).

**Special notes for your reviewer**:
Only tested on my machine, seemed to work there. There is another usage in [this](https://github.com/okkur/syna/blob/master/layouts/partials/helpers/config.html) file, but I was not sure how it is used and therefore did not touch it.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Fix bug that created localized urls for static assets.
```
