### PR TITLE
exclude current lang in navbar, better alignment, use languageName

### DIFF
--- a/exampleSite/content/docs/multilingual/content.md
+++ b/exampleSite/content/docs/multilingual/content.md
@@ -23,22 +23,27 @@ for German website if those pages are not translated to German. For more
 information on Hugo's Multilingual mode, please refer to [their documentation](https://gohugo.io/content-management/multilingual/).
 
 In order to configure two languages, you need to update your main your
-configuration. Here's an example from the official documentation:
+configuration. Here's an example, derived from the official documentation:
 
 ```
 DefaultContentLanguage = "en"
 
 [languages]
   [languages.en]
+    languageName = "English"
     title = "My blog"
     weight = 1
   [languages.fr]
+    languageName = "Français"
     title = "Mon blogue"
     weight = 2
 
 [params]
   ...
 ```
+
+The `languageName` parameter is used as text on the language switcher buttons
+in the navbar.
 
 Please note that these parameters are added outside of `params` variable, inside
 your configuration file (`config.toml`, `config.yaml`, `config.json`). This will

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -36,7 +36,7 @@
       {{- else -}}
         {{- printf " justify-content-end " -}}
       {{- end -}} collapse show" id="navbarCollapse">
-      <ul class="navbar-nav">
+      <ul class="navbar-nav mr-2">
         {{- if .Params.prepend -}}
           {{- range sort .Params.prepend }}
             {{- $isMenuCurrent := or (eq $.root.Permalink .url) (eq (printf "%s/" $.root.Permalink) .url) (eq $.root.Permalink (printf "%s/" .url)) -}}
@@ -102,9 +102,11 @@
       {{- end }}
       {{- if .Site.IsMultiLingual -}}
         {{- range .Site.Languages }}
-          <a class="btn btn-secondary p-1 m-1" href="{{ delimit (slice "/" .) "" }}" role="button">
-            {{ . }}
-          </a>
+          {{- if ne .Lang $.Site.Language.Lang -}}
+            <a class="btn btn-secondary mr-1 my-2" href="{{ delimit (slice "/" .) "" }}" role="button">
+              {{ .LanguageName }}
+            </a>
+          {{- end -}}
         {{- end -}}
       {{- end }}
     </div>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:

This mainly aims at improving the optics of the language switching buttons in multi-lang mode.

* exclude the currently used language to yield space in the navbar
* improve button optics and alignment in menu bar and collapsed menu
* use long language name as button text to make it more user friendly
* update documentation

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Improved look and alignment of language switcher buttons, exclude currently used language
```
