### PR TITLE
Fix duplicate section pages in list fragment

### DIFF
--- a/layouts/partials/helpers/list-pages.html
+++ b/layouts/partials/helpers/list-pages.html
@@ -10,9 +10,11 @@
   {{- end -}}
 {{- end -}}
 
-{{- .page_scratch.Set "pages" (.page_scratch.Get "page").Pages -}}
-{{- if .Params.subsections -}}
-  {{- .page_scratch.Add "pages" (.page_scratch.Get "page").Sections -}}
+{{- .page_scratch.Set "pages" slice -}}
+{{- range (.page_scratch.Get "page").Pages -}}
+  {{- if or $.Params.subsections (ne .Kind "section") -}}
+    {{- $.page_scratch.Add "pages" . -}}
+  {{- end -}}
 {{- end -}}
 {{- if .Params.subsection_leaves -}}
   {{- range (.page_scratch.Get "page").Sections -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
`.Pages` previously only returned pages with `.Kind eq "page"` but now it returns all pages under a section. Changed our list helper to collect pages based on their `.Kind` if `subsections` is not set or is set to false.

**Which issue this PR fixes**:
fixes #751

**Release note**:
```release-note
- list: Fix a bug that caused subsections be shown if the config was set to not show them or show duplicate subsections if config was set to show them.
```
