### PR TITLE
Fix events tests' bad selector error

### DIFF
--- a/cypress/integration/events.spec.js
+++ b/cypress/integration/events.spec.js
@@ -5,7 +5,7 @@ describe("Events", () => {
 
   it("should focus stripe form when stripe event is fired", () => {
     cy.get(
-      "a[href='/dev/events/payment?event=pricing:change&product=Starting%20plan&price=$9.99/mo&currency=usd']"
+      "a[href$='/dev/events/payment?event=pricing:change&product=Starting%20plan&price=$9.99/mo&currency=usd']"
     ).click();
     cy.get("#stripe input[name=email]").should("focused", true);
     cy.get("#stripe .price-display .btn-group label")
@@ -15,7 +15,7 @@ describe("Events", () => {
 
   it("should focus contact form when contact event is fired", () => {
     cy.get(
-      "a[href='/dev/events/payment?e=P2V2ZW50PWNvbnRhY3Q6dXBkYXRlJm1lc3NhZ2U9VGl0bGU6IExldCdzIG5lZ290aWF0ZQpQbGFuOiBFbnRlcnByaXNlIHBsYW4KWW91ciBtZXNzYWdlOgo=']"
+      "a[href$='/dev/events/payment?e=P2V2ZW50PWNvbnRhY3Q6dXBkYXRlJm1lc3NhZ2U9VGl0bGU6IExldCdzIG5lZ290aWF0ZQpQbGFuOiBFbnRlcnByaXNlIHBsYW4KWW91ciBtZXNzYWdlOgo=']"
     ).click();
     cy.get("#contact input[name=name]").should("focused", true);
     cy.get("#contact textarea[name=message]").should(


### PR DESCRIPTION
**What this PR does / why we need it**:
`relLangURL` had caused the urls in pricing fragment to change from absolute to relative, which in turn invalidated the selectors in our tests. Changing from exact match (`[href=/path]`) to regex match (`[href$=/href]`) fixed the problem.

**Which issue this PR fixes**:
fixes #748
