### PR TITLE
Fix list item count in the list test

### DIFF
--- a/cypress/integration/list.spec.js
+++ b/cypress/integration/list.spec.js
@@ -1,8 +1,8 @@
 describe("List fragment", () => {
   it("should display pages from same, specific section, with subsections and with subsection leaves", () => {
     cy.visit("/dev/list");
-    cy.get("#upper-leaves article").should("have.length", 4);
-    cy.get("#branches article").should("have.length", 6);
-    cy.get("#leaves article").should("have.length", 10);
+    cy.get("#upper-leaves article").should("have.length", 2);
+    cy.get("#branches article").should("have.length", 4);
+    cy.get("#leaves article").should("have.length", 8);
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous test was wrong since I hadn't realized list fragment was outputing extra content. Since the fragment was fixed and the test was hard coded, it was failing.