### PR TITLE
Fix alignment of contact fragment submit button

### DIFF
--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -85,7 +85,7 @@ function checkReCaptcha() {
   ) {
     $('.captcha-error').removeClass('d-none');
     setTimeout(checkReCaptcha, 200);
-  } else {
+  } else if (document.querySelector('.g-recaptcha-container div div')) {
     $('.captcha-error').addClass('d-none');
     $('.g-recaptcha-filler').addClass('d-none');
     $('.g-recaptcha').attr('disabled', true);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix alignment of contact fragment submit button when recaptcha is not fully loaded

**Which issue this PR fixes**:
fixes #722

**Special notes for your reviewer**:
I'm not sure if this will fix the issue or not. I can't test it locally but in theory it should work. I tried to check whether or not the recaptcha badge is loaded into the dom. Since flex will break when we hide the filler right after if see the recaptcha, checking a deeper element should fix the issue.

**Release note**:
```release-note
- contact: fix alignment of contact fragment's submit button when recaptcha is not fully loaded
```
