### PR TITLE
Fix hero image params' height issue

### DIFF
--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -43,8 +43,10 @@
               {{- print $.Params.title -}}
             {{- end -}}
           "
-          {{- if .height }} height="{{ .height }}"{{- end -}}
-          {{- if .width }} width="{{ .width }}"{{- end -}}
+          style="
+            {{- if .height }}height: {{ .height }} !important;{{- end -}}
+            {{- if .width }}width: {{ .width }} !important;{{- end -}}
+          "
         ></img>
       </div>
     {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix image height not working on hero.asset.

**Which issue this PR fixes**:
fixes #734 

**Special notes for your reviewer**:

**Release note**:
```release-note
- hero: image.height works without an issue now
```
