### PR TITLE
Fix broken if and statement

### DIFF
--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -7,7 +7,7 @@
 {{- range sort ($page_scratch.Get "page_fragments" | default slice) "Params.weight" -}}
   {{/* If a fragment contains a slot variable in it's frontmatter it should not
     be rendered on the page. It would be later handled by the slot helper. */}}
-  {{- if (not (isset .Params "slot")) (ne .Params.slot "") -}}
+  {{- if and (not (isset .Params "slot")) (ne .Params.slot "") -}}
     {{/* Cleanup .Name to be more useful within fragments */}}
     {{- $name := cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" "")) -}}
     {{- $bg := .Params.background | default "light" }}


### PR DESCRIPTION
Updates to hugo 0.71.1 causes a previously allowed-but-wrong construct to now be disallowed.  This fixes the template to now compile on 0.71.1

Fixes okkur/syna#773

<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Fixes an template that is now illegal in hugo 0.71.1
<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #773 
-->

**Special notes for your reviewer**:
Also discussed in gohugoio/hugo#7325
**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Fixes template error in hugo 0.71.1
```
