### PR TITLE
Fix nav fragment to allow multiple navs per page

### DIFF
--- a/cypress/integration/navbar.spec.js
+++ b/cypress/integration/navbar.spec.js
@@ -27,4 +27,19 @@ describe("Navbar", () => {
     cy.get('[data-toggle="collapse"][data-target="#navbarCollapse"]').click();
     cy.get("#navbarCollapse").should("be.hidden");
   });
+
+  it("should show search results with multiple navs in page", () => {
+    cy.visit("/dev/nav-multiple/");
+    cy.get('#nav-1 .search-container input').focus().type('nav');
+    cy.get('#nav-1 .search-results-container').should("be.visible");
+    cy.get('#nav-2 .search-results-container').should("be.hidden");
+    cy.get('#nav-1').click();
+    cy.get('#nav-1 .search-results-container').should("be.hidden");
+
+    cy.get('#nav-2 .search-container input').focus().type('nav');
+    cy.get('#nav-2 .search-results-container').should("be.visible");
+    cy.get('#nav-1 .search-results-container').should("be.hidden");
+    cy.get('#nav-2').click();
+    cy.get('#nav-2 .search-results-container').should("be.hidden");
+  });
 });

--- a/exampleSite/content/dev/nav-multiple/index.md
+++ b/exampleSite/content/dev/nav-multiple/index.md
@@ -1,0 +1,8 @@
++++
+title = "Multiple Nav Fragment"
+fragment = "content"
+weight = 100
++++
+
+This page should show the global navigation along with two page specific nav
+fragments.

--- a/exampleSite/content/dev/nav-multiple/nav-1.md
+++ b/exampleSite/content/dev/nav-multiple/nav-1.md
@@ -1,0 +1,23 @@
++++
+fragment = "nav"
+date = "2018-05-17"
+weight = 110
+background = "secondary"
+search = true
+#sticky = true # Default is false
+
+[breadcrumb]
+  display = true # Default value is false
+  #level = 0 # Default is 1
+  background = "light"
+
+# Branding options
+[asset]
+  image = "logo.svg"
+  text = "Syna"
+
+[repo_button]
+  url = "https://github.com/okkur/syna"
+  text = "Star" # default: "Star"
+  icon = "fab fa-github" # defaults: "fab fa-github"
++++

--- a/exampleSite/content/dev/nav-multiple/nav-2.md
+++ b/exampleSite/content/dev/nav-multiple/nav-2.md
@@ -1,0 +1,23 @@
++++
+fragment = "nav"
+date = "2018-05-17"
+weight = 120
+background = "dark"
+search = true
+#sticky = true # Default is false
+
+[breadcrumb]
+  display = true # Default value is false
+  #level = 0 # Default is 1
+  background = "light"
+
+# Branding options
+[asset]
+  image = "logo.svg"
+  text = "Syna"
+
+[repo_button]
+  url = "https://github.com/okkur/syna"
+  text = "Star" # default: "Star"
+  icon = "fab fa-github" # defaults: "fab fa-github"
++++

--- a/layouts/partials/fragments/nav.html
+++ b/layouts/partials/fragments/nav.html
@@ -158,7 +158,7 @@
     {{- else -}}
       {{- printf " navbar-%s" "dark" -}}
     {{- end -}}
-  " id="{{ .Name }}">
+  " id="{{ .Name }}-breadcrumb">
     <div class="container">
       <ol class="breadcrumb mb-0 py-1">
         {{- $item_count := sub (len ($page_scratch.Get "crumbs")) $level -}}
@@ -198,29 +198,31 @@
 {{- if .Params.search }}
 {{ partial "helpers/search-result-template.html" (dict "self" $self "name" .Name "message_class" "p-2" "background" $bg) }}
 <script>
-  var fragmentName = "{{ .Name }}";
-  window.syna.api.register('search', 'search-' + fragmentName, {
-    searchInput: '#search-query-{{ .Name }}',
-    resultsContainer: '#search-results-{{ .Name }}',
-    template: '#search-result-template-{{ .Name }}',
-    noResults: '#search-no-results-template-{{ .Name }}',
-    empty: '#search-empty-template-{{ .Name }}',
-  });
+  (function() {
+    var fragmentName = "{{ .Name }}";
+    window.syna.api.register('search', 'search-' + fragmentName, {
+      searchInput: `#search-query-${fragmentName}`,
+      resultsContainer: `#search-results-${fragmentName}`,
+      template: `#search-result-template-${fragmentName}`,
+      noResults: `#search-no-results-template-${fragmentName}`,
+      empty: `#search-empty-template-${fragmentName}`,
+    });
 
-  var resultsContainer = document.querySelector('.search-results-container');
-  document.querySelector('#search-query-{{ .Name }}').addEventListener('input', function(e) {
-    if (e.target.value.length) {
-      resultsContainer.classList.add('show');
-    } else {
-      resultsContainer.classList.remove('show');
-    }
-  });
+    var resultsContainer = document.querySelector(`#${fragmentName} .search-results-container`)
+    document.querySelector(`#search-query-${fragmentName}`).addEventListener('input', function(e) {
+      if (e.target.value.length) {
+        resultsContainer.classList.add('show');
+      } else {
+        resultsContainer.classList.remove('show');
+      }
+    });
 
-  document.addEventListener('click', function(e) {
-    if (!document.querySelector('.search-container').contains(e.target)) {
-      document.querySelector('#search-query-{{ .Name }}').value = '';
-      resultsContainer.classList.remove('show');
-    }
-  });
+    document.addEventListener('click', function(e) {
+      if (!document.querySelector(`#${fragmentName} .search-container`).contains(e.target)) {
+        document.querySelector(`#search-query-${fragmentName}`).value = '';
+        resultsContainer.classList.remove('show');
+      }
+    });
+  })();
 </script>
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the search script in the nav fragment, allowing multiple nav fragments to use search in the same page.

**Which issue this PR fixes**:
fixes #388 

**Special notes for your reviewer**:
The sticky option can be used but we may need to rethink how it might function differently for multiple nav fragments. Right now if you have two sticky navs, they are followed by each other on top of the page. If we need a different behavior, I suggest doing so in a separate issue.

**Release note**:
```release-note
- nav: Fix the bug that prevented search from working if there were multiple nav fragments in one page
```
