### PR TITLE
Update subitems helper to fix multilingual issue

### DIFF
--- a/layouts/partials/helpers/subitems.html
+++ b/layouts/partials/helpers/subitems.html
@@ -3,7 +3,9 @@
 {{- $name := .Name -}}
 {{- $site := .Site -}}
 {{- $page_scratch := .page_scratch -}}
-{{- $items := where ($page.Resources.Match (printf "%s/*.md" $name)) ".Name" "ne" $self.Name -}}
+{{ $default_lang := .root.Site.Params.DefaultContentLanguage | default .root.Site.Language.Lang }}
+
+{{- $items := where ($page.Resources.Match (printf "%s/*.md" (strings.TrimSuffix (cond (ne $default_lang $page.Language.Lang) (printf "/index.%s" $page.Language.Lang) "") $name))) ".Name" "ne" $self.Name -}}
 
 {{- if eq (len $items) 0 -}}
   {{- range $directory := ($page_scratch.Get "fragment_directories") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
`subitems` helper didn't identify page resources correctly in multilingual websites. The problem appeared in not default language pages.

**Which issue this PR fixes**:
fixes #799 

**Release note**:
```release-note
- Fix multilingual pages not showing subitems of fragments in non default language page
```
