### PR TITLE
Fix rel lang fragment name issue

### DIFF
--- a/cypress/integration/main-js.spec.js
+++ b/cypress/integration/main-js.spec.js
@@ -31,7 +31,7 @@ describe('index.js (assets/scripts/main.js)', () => {
     cy.get('#dropdown .dropdown-toggle').should('contain', '$');
     cy.get('#dropdown .dropdown-toggle')
       .parent()
-      .get('.dropdown-menu .dropdown-item:nth-child(2)')
+      .get('.currency-menu .dropdown-item:nth-child(2)')
       .click();
     cy.get('#dropdown .dropdown-toggle')
       .parent()

--- a/layouts/partials/fragments/buttons.html
+++ b/layouts/partials/fragments/buttons.html
@@ -1,7 +1,7 @@
 {{- $self := .self -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row text-center justify-content-center">
     {{- range .Params.buttons }}

--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -7,7 +7,7 @@
 
 {{ "<!-- Contact -->" | safeHTML }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row">
     <div class="col-12">

--- a/layouts/partials/fragments/content.html
+++ b/layouts/partials/fragments/content.html
@@ -2,7 +2,7 @@
 {{- .page_scratch.Add "js" (dict "file" "syna-content.js") -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params "section_class" "content-fragment" "container_class" "overlay") -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params "section_class" "content-fragment" "container_class" "overlay") -}}
   <div class="row">
     {{- with .Params.sidebar -}}
       <div class="content-sidebar col-md-3 pb-4 px-md-0 {{- if (eq .align "right") }} order-1 {{- else }} order-0 {{- end -}}">

--- a/layouts/partials/fragments/editor.html
+++ b/layouts/partials/fragments/editor.html
@@ -3,7 +3,7 @@
 {{- .page_scratch.Set "react" true -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   <div data-portal></div>
 {{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}
 {{- if .page.File.Dir -}}

--- a/layouts/partials/fragments/embed.html
+++ b/layouts/partials/fragments/embed.html
@@ -3,7 +3,7 @@
 {{- $size := .Params.size | default "75" -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row justify-content-center">
     {{- if eq .Params.responsive false }}

--- a/layouts/partials/fragments/faq.html
+++ b/layouts/partials/fragments/faq.html
@@ -4,7 +4,7 @@
 {{- $bg := .Params.background | default "white" -}}
 {{- .page_scratch.Add "js" (dict "file" "syna-collapse.js") -}}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row text-center justify-content-center">
     <div class="faq">
@@ -15,8 +15,8 @@
           {{/* Handle special case of index.md being considered an item */}}
           {{- if not (in .Name "/index.md") -}}
             {{- $item := .Params }}
-            {{- $card_header_id := printf "%s" (strings.TrimSuffix ".md" (replace .Name (printf "%s/" $.Name) "")) }}
-            {{- $collapse_id := printf "%s%s" $.Name (printf "%s-collapse" (strings.TrimSuffix ".md" (replace .Name (printf "%s/" $.Name) ""))) }}
+            {{- $card_header_id := printf "%s" (strings.TrimSuffix ".md" (replace .Name (printf "%s/" $.id) "")) }}
+            {{- $collapse_id := printf "%s%s" $.id (printf "%s-collapse" (strings.TrimSuffix ".md" (replace .Name (printf "%s/" $.id) ""))) }}
               <div class="card">
                 <div id="{{ $card_header_id }}" class="card-header" data-toggle="collapse" data-target="#{{ $collapse_id }}"
                             aria-expanded="false" aria-controls="{{ $collapse_id }}">

--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -1,7 +1,7 @@
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) }}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) }}
   <div class="row">
     <div class="col-md m-2
       {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}

--- a/layouts/partials/fragments/graph.html
+++ b/layouts/partials/fragments/graph.html
@@ -2,7 +2,7 @@
 {{- .page_scratch.Add "js" (dict "file" "syna-graph.js") -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row chart-container position-relative" style="
     {{- (cond (isset .Params "width") (printf "width: %s;" .Params.width) (print "width: 100%;")) | safeCSS -}}

--- a/layouts/partials/fragments/header.html
+++ b/layouts/partials/fragments/header.html
@@ -3,6 +3,6 @@
 {{- $subtitle_align := .Params.subtitle_align | default $align -}}
 {{- $bg := $self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) -}}
 {{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}

--- a/layouts/partials/fragments/item.html
+++ b/layouts/partials/fragments/item.html
@@ -2,7 +2,7 @@
 {{- $align := .Params.align | default "center" -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) }}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) }}
   <div class="row align-items-center text-center
     {{- if eq $align "left" -}}
       {{- printf " justify-content-start text-lg-left" -}}

--- a/layouts/partials/fragments/items.html
+++ b/layouts/partials/fragments/items.html
@@ -3,7 +3,7 @@
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   <div class="row justify-content-center align-items-stretch items">
     {{- if eq (len $items) 0 -}}

--- a/layouts/partials/fragments/list.html
+++ b/layouts/partials/fragments/list.html
@@ -6,7 +6,7 @@
 {{- $sorted_pages := $list_pages.sorted_pages -}}
 
 {{- $bg := .self.Scratch.Get "bg" }}
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   <div class="row mx-0
     {{- partial "helpers/text-color.html" (dict "self" $self.self "light" "secondary") -}}

--- a/layouts/partials/fragments/member.html
+++ b/layouts/partials/fragments/member.html
@@ -3,7 +3,7 @@
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   {{- if eq (len $items) 0 -}}
     {{- partial "helpers/empty-subpath.html" (dict "context" "member" "root" $) -}}

--- a/layouts/partials/fragments/portfolio.html
+++ b/layouts/partials/fragments/portfolio.html
@@ -4,7 +4,7 @@
 {{- .page_scratch.Add "js" (dict "file" "syna-portfolio.js") -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   <div class="row justify-content-center">
     {{- if eq (len $items) 0 }}

--- a/layouts/partials/fragments/pricing.html
+++ b/layouts/partials/fragments/pricing.html
@@ -4,7 +4,7 @@
 {{- $self := . -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   {{- with .Content -}}
     <div class="row">

--- a/layouts/partials/fragments/react-portal.html
+++ b/layouts/partials/fragments/react-portal.html
@@ -2,7 +2,6 @@
 {{- .page_scratch.Set "react" true -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   <div data-portal></div>
 {{- partial "helpers/container.html" (dict "end" true "in_slot" .in_slot) -}}
-

--- a/layouts/partials/fragments/search.html
+++ b/layouts/partials/fragments/search.html
@@ -2,7 +2,7 @@
 {{- .page_scratch.Add "js" (dict "file" "syna-search.js") -}}
 {{- $bg := .self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self.self "bg" $bg "params" .Params) }}
   <div class="row w-100 justify-content-center mx-0">
     <form action="{{ "search" | absURL }}" class="mt-0">

--- a/layouts/partials/fragments/stripe.html
+++ b/layouts/partials/fragments/stripe.html
@@ -4,7 +4,7 @@
 {{- .page_scratch.Add "js" (dict "file" "syna-stripe.js") -}}
 {{- $bg := $self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) -}}
   {{- if and .Params.user_input (eq (len (.Params.prices | default slice)) 1) -}}
     {{- partial "helpers/warning.html" (dict "Site" $.Site "message" "You have configured both `[user_input]` and a single `[[prices]]` which is not allowed.") -}}

--- a/layouts/partials/fragments/table.html
+++ b/layouts/partials/fragments/table.html
@@ -1,7 +1,7 @@
 {{- $self := .self -}}
 {{- $bg := $self.Scratch.Get "bg" }}
 
-{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params) -}}
+{{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "id" .id "Params" .Params) -}}
   {{- partial "helpers/section-header.html" (dict "self" $self "bg" $bg "params" .Params) }}
   <div class="row align-items-center text-center justify-content-end">
     <div class="col-12 order-lg-1 text-center">

--- a/layouts/partials/helpers/container.html
+++ b/layouts/partials/helpers/container.html
@@ -2,7 +2,7 @@
 {{ (printf "<!-- %s -->" (humanize .Params.fragment)) | safeHTML }}
 {{- end }}
 {{- if .start }}
-<section id="{{ .Name }}" class="{{- printf "fragment %s" (.section_class | default "") -}}">
+<section id="{{ .id }}" class="{{- printf "fragment %s" (.section_class | default "") -}}">
   {{- if ne .in_slot true }}
     <div class="{{- printf "container-fluid bg-%s %s" .bg (.container_class | default "") -}}">
   {{- end }}

--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -18,7 +18,7 @@
     {{- .Scratch.Set "bg" $bg -}}
 
     {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
-    {{- $context := dict "page_scratch" $page_scratch "root" $real_page "Site" $real_page.Site "page" $page "resources" $real_page.Resources "self" . "Params" .Params "Name" ($page_scratch.Get "tmp_name") "file_path" $file_path }}
+    {{- $context := dict "id" (replaceRE "[\\/\\.]" "-" ($page_scratch.Get "tmp_name")) "page_scratch" $page_scratch "root" $real_page "Site" $real_page.Site "page" $page "resources" $real_page.Resources "self" . "Params" .Params "Name" ($page_scratch.Get "tmp_name") "file_path" $file_path }}
     {{- partial (print "fragments/" .Params.fragment ".html") $context -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -18,6 +18,13 @@
     {{- .Scratch.Set "bg" $bg -}}
 
     {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
+    {{/* 
+      "id" is used in every fragment as a unique identifier, added to html as,
+      the id attribute. We also have "name" which is the name of the fragment,
+      (not the fragment itself), without the language suffix (if present), and,
+      without the extra index.md that appears if the fragment is in a,
+      subdirectory.
+    */}}
     {{- $context := dict "id" (replaceRE "[\\/\\.]" "-" ($page_scratch.Get "tmp_name")) "page_scratch" $page_scratch "root" $real_page "Site" $real_page.Site "page" $page "resources" $real_page.Resources "self" . "Params" .Params "Name" ($page_scratch.Get "tmp_name") "file_path" $file_path }}
     {{- partial (print "fragments/" .Params.fragment ".html") $context -}}
   {{- end -}}

--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -10,13 +10,15 @@
     be rendered on the page. It would be later handled by the slot helper. */}}
   {{- if and (not (isset .Params "slot")) (ne .Params.slot "") -}}
     {{/* Cleanup .Name to be more useful within fragments */}}
-    {{- $rel_lang_name := cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" "")) -}}
-    {{- $name := strings.TrimSuffix (cond (ne $default_lang $page.Language.Lang) (printf ".%s" $page.Language.Lang) "") $rel_lang_name -}}
+    {{- $page_scratch.Set "tmp_name" (cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" ""))) -}}
+    {{- if ne $page.Language nil -}}
+      {{- $page_scratch.Set "tmp_name" (strings.TrimSuffix (cond (ne $default_lang $page.Language.Lang) (printf ".%s" $page.Language.Lang) "") ($page_scratch.Get "tmp_name")) -}}
+    {{- end -}}
     {{- $bg := .Params.background | default "light" }}
     {{- .Scratch.Set "bg" $bg -}}
 
     {{- $file_path := strings.TrimSuffix ".md" (replace .File.Path "/index.md" "") -}}
-    {{- $context := dict "page_scratch" $page_scratch "root" $real_page "Site" $real_page.Site "page" $page "resources" $real_page.Resources "self" . "Params" .Params "Name" $name "file_path" $file_path }}
+    {{- $context := dict "page_scratch" $page_scratch "root" $real_page "Site" $real_page.Site "page" $page "resources" $real_page.Resources "self" . "Params" .Params "Name" ($page_scratch.Get "tmp_name") "file_path" $file_path }}
     {{- partial (print "fragments/" .Params.fragment ".html") $context -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -3,13 +3,15 @@
 {{- $page := $layout_info.page -}}
 {{- $real_page := $layout_info.real_page -}}
 {{- $root := $layout_info.root -}}
+{{- $default_lang := $root.Site.Params.DefaultContentLanguage | default $root.Site.Language.Lang -}}
 
 {{- range sort ($page_scratch.Get "page_fragments" | default slice) "Params.weight" -}}
   {{/* If a fragment contains a slot variable in it's frontmatter it should not
     be rendered on the page. It would be later handled by the slot helper. */}}
   {{- if and (not (isset .Params "slot")) (ne .Params.slot "") -}}
     {{/* Cleanup .Name to be more useful within fragments */}}
-    {{- $name := cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" "")) -}}
+    {{- $rel_lang_name := cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" "")) -}}
+    {{- $name := strings.TrimSuffix (cond (ne $default_lang $page.Language.Lang) (printf ".%s" $page.Language.Lang) "") $rel_lang_name -}}
     {{- $bg := .Params.background | default "light" }}
     {{- .Scratch.Set "bg" $bg -}}
 

--- a/layouts/partials/helpers/subitems.html
+++ b/layouts/partials/helpers/subitems.html
@@ -3,9 +3,8 @@
 {{- $name := .Name -}}
 {{- $site := .Site -}}
 {{- $page_scratch := .page_scratch -}}
-{{ $default_lang := .root.Site.Params.DefaultContentLanguage | default .root.Site.Language.Lang }}
 
-{{- $items := where ($page.Resources.Match (printf "%s/*.md" (strings.TrimSuffix (cond (ne $default_lang $page.Language.Lang) (printf "/index.%s" $page.Language.Lang) "") $name))) ".Name" "ne" $self.Name -}}
+{{- $items := where ($page.Resources.Match (printf "%s/*.md" (strings.TrimSuffix "/index" $name))) ".Name" "ne" $self.Name -}}
 
 {{- if eq (len $items) 0 -}}
   {{- range $directory := ($page_scratch.Get "fragment_directories") -}}

--- a/layouts/partials/helpers/subitems.html
+++ b/layouts/partials/helpers/subitems.html
@@ -4,14 +4,19 @@
 {{- $site := .Site -}}
 {{- $page_scratch := .page_scratch -}}
 
-{{- $items := where ($page.Resources.Match (printf "%s/*.md" (strings.TrimSuffix "/index" $name))) ".Name" "ne" $self.Name -}}
+{{- $page_scratch.Set "tmp_items" (where ($page.Resources.Match (printf "%s/*.md" (strings.TrimSuffix "/index" $name))) ".Name" "ne" $self.Name) -}}
 
-{{- if eq (len $items) 0 -}}
+{{- if eq (len ($page_scratch.Get "tmp_items")) 0 -}}
   {{- range $directory := ($page_scratch.Get "fragment_directories") -}}
-    {{- if eq (len $items) 0 -}}
-      {{- $items = where ($directory.Resources.Match (printf "%s/*.md" $name)) ".Name" "ne" $self.Name -}}
+    {{- if eq (len ($page_scratch.Get "tmp_items")) 0 -}}
+      {{- $page_scratch.Set "tmp_items" (where ($directory.Resources.Match (printf "%s/*.md" $name)) ".Name" "ne" $self.Name) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
 
-{{- return $items -}}
+{{- $page_scratch.Set "tmp_subitems" slice -}}
+{{- range ($page_scratch.Get "tmp_items") -}}
+  {{- $page_scratch.Add "tmp_subitems" (dict "Name" (replaceRE "[\\/\\.]" "-" .Name) "Params" .Params "File" .File "ResourceType" .ResourceType "Title" .Title "Permalink" .Permalink "RelPermalink" .RelPermalink "Content" .Content "MediaType" .MediaType "MediaType.MainType" .MediaType.MainType "MediaType.SubType" .MediaType.SubType "MediaType.Suffixes" .MediaType.Suffixes) -}}
+{{- end -}}
+
+{{- return ($page_scratch.Get "tmp_subitems") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fragment names didn't omit language name which was causing JS selectors to fail. This PR renames `<fragment>.<lang>` to `<fragment>`.

**Which issue this PR fixes**:
fixes #798 
fixes #799 

**Release note**:
```release-note
- Fix scripts not working in multilingual websites properly
```
