### PR TITLE
Add allowlist to repositories_github

### DIFF
--- a/exampleSite/content/fragments/repositories_github/code-repositories_github.md
+++ b/exampleSite/content/fragments/repositories_github/code-repositories_github.md
@@ -14,6 +14,7 @@ user = "okkur"
 count = 4 # default is 4
 display_forks = false # default is false
 sort = "stargazers_count" # default is "stargazers_count"
+# allowlist = ["syna", "syna-start"]
 +++
 ```
 </details>

--- a/exampleSite/content/fragments/repositories_github/docs.md
+++ b/exampleSite/content/fragments/repositories_github/docs.md
@@ -35,4 +35,9 @@ This key is used to sort the repositories.
 
 **Note:** This value is a key from the response of Github's repositories API. Also the sort is done using Hugo's `sort` function.
 
+#### allowlist
+*type: array of string*
+
+A filter that is applied to repository names. Only repositories that are named in this list will be rendered.
+
 [Global variables]({{< ref "global-variables" >}}) are documented as well and have been omitted from this page.

--- a/exampleSite/content/fragments/repositories_github/repositories_github.md
+++ b/exampleSite/content/fragments/repositories_github/repositories_github.md
@@ -7,4 +7,5 @@ user = "okkur"
 count = 4 # default is 4
 display_forks = false # default is false
 sort = "stargazers_count" # default is "stargazers_count"
+# allowlist = ["syna", "syna-start"]
 +++

--- a/layouts/partials/fragments/repositories_github.html
+++ b/layouts/partials/fragments/repositories_github.html
@@ -6,6 +6,10 @@
   {{- .page_scratch.Set "tmp_repositories" (where (.page_scratch.Get "tmp_repositories") ".fork" "eq" false) -}}
 {{- end -}}
 
+{{- if isset .Params "allowlist" -}}
+  {{- .page_scratch.Set "tmp_repositories" (where (.page_scratch.Get "tmp_repositories") ".name" "in" (.Params.allowlist | default slice)) -}}
+{{- end -}}
+
 {{- $repositories := (.page_scratch.Get "tmp_repositories") -}}
 
 {{- partial "helpers/container.html" (dict "start" true "in_slot" .in_slot "bg" $bg "Name" .Name "Params" .Params "section_class" "content-fragment" "container_class" "overlay") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new variable `allowlist` to `repositories_github` fragment, filtering repositories by name.

**Which issue this PR fixes**:
fixes #805 

**Release note**:
```release-note
- repositories_github: Add new `allowlist` variable
```
