### PR TITLE
Fix postcss issues

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -52,8 +52,23 @@
   {{- $sassTemplate := resources.Get "styles/index.scss" -}}
   {{- $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true "includePaths" (slice "node_modules" "styles")) -}}
   {{- $styleTemplated := $sassTemplate | resources.ExecuteAsTemplate "main.scss" . -}}
-  {{- $style := $styleTemplated | resources.ToCSS $options | resources.PostCSS | resources.Minify | resources.Fingerprint | resources.PostProcess }}
-  <link href="{{ $style.Permalink }}" rel="stylesheet">
+  {{- if hugo.IsProduction -}}
+    {{- if .Site.Params.postcss -}}
+      {{- $style := $styleTemplated | resources.ToCSS $options | resources.PostCSS | resources.Minify | resources.Fingerprint | resources.PostProcess }}
+      <link href="{{ $style.Permalink }}" rel="stylesheet">
+    {{- else -}}
+      {{- $style := $styleTemplated | resources.ToCSS $options | resources.Minify | resources.Fingerprint }}
+      <link href="{{ $style.Permalink }}" rel="stylesheet">
+    {{- end -}}
+  {{- else -}}
+    {{- if .Site.Params.postcss -}}
+      {{- $style := $styleTemplated | resources.ToCSS $options | resources.PostCSS | resources.PostProcess }}
+      <link href="{{ $style.Permalink }}" rel="stylesheet">
+    {{- else -}}
+      {{- $style := $styleTemplated | resources.ToCSS $options }}
+      <link href="{{ $style.Permalink }}" rel="stylesheet">
+    {{- end -}}
+  {{- end -}}
 
   {{- with .Site.Params.custom -}}
     {{- with .favicon }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable postcss asset pipes by default, it requires `postcss` variable to be set to `true` in site's `Params` config.

**Which issue this PR fixes**:
fixes #813 

**Special notes for your reviewer**:

**Release note**:
```release-note
- Fix issue preventing site build when `postcss-cli` is not installed
```
