### PR TITLE
Add new global variable hide

### DIFF
--- a/exampleSite/content/dev/fragment-fallthrough/_global/config.md
+++ b/exampleSite/content/dev/fragment-fallthrough/_global/config.md
@@ -1,0 +1,9 @@
++++
+fragment = "config"
+
+[[config]]
+  type = "js"
+  html = """<script>
+  document.querySelector("#content .title-container h2").style.color = "red";
+</script>"""
++++

--- a/exampleSite/content/dev/fragment-fallthrough/_global/hidden.md
+++ b/exampleSite/content/dev/fragment-fallthrough/_global/hidden.md
@@ -1,0 +1,5 @@
++++
+fragment = "content"
+weight = 110
+title = "If you're seeing this, hide and fallthrough don't work"
++++

--- a/exampleSite/content/dev/fragment-fallthrough/_index/config.md
+++ b/exampleSite/content/dev/fragment-fallthrough/_index/config.md
@@ -1,0 +1,4 @@
++++
+fragment = "config"
+hide = true
++++

--- a/exampleSite/content/dev/fragment-fallthrough/_index/content.md
+++ b/exampleSite/content/dev/fragment-fallthrough/_index/content.md
@@ -1,7 +1,7 @@
 +++
 fragment = "content"
 weight = 100
-title = "Content fragment from Page"
+title = "Content fragment from Page, this text should be black"
 +++
 
 This is loaded from the page, overriding the globals of current section. Seems

--- a/exampleSite/content/dev/fragment-fallthrough/_index/hidden.md
+++ b/exampleSite/content/dev/fragment-fallthrough/_index/hidden.md
@@ -1,0 +1,6 @@
++++
+fragment = "content"
+weight = 110
+title = "If you're seeing this, hide doesn't work"
+hide = true
++++

--- a/exampleSite/content/docs/fragments/content.md
+++ b/exampleSite/content/docs/fragments/content.md
@@ -84,6 +84,8 @@ All fragments within this directory are rendered on all pages by default.
 To overwrite a global fragment create a per page fragment with the same filename.
 This would overwrite the global one.
 
+Also in order to hide a global fragment in a specific page or section, you can use the [`hide` global variable]({{< ref "global-variables">}}/#hide).
+
 Aside from the `content/_global/` directory, you can create `_global/` directory in any section's directory (`content/[section]/_global/`).
 Each section can have global fragments and if there are multiple fragments with the same name, the fragment closest to the page would override the others.
 

--- a/exampleSite/content/docs/fragments/content.md
+++ b/exampleSite/content/docs/fragments/content.md
@@ -84,7 +84,7 @@ All fragments within this directory are rendered on all pages by default.
 To overwrite a global fragment create a per page fragment with the same filename.
 This would overwrite the global one.
 
-Also in order to hide a global fragment in a specific page or section, you can use the [`hide` global variable]({{< ref "global-variables">}}/#hide).
+In order to hide a global fragment in a specific page or section, you can use the [`hide` global variable]({{< ref "global-variables">}}/#hide).
 
 Aside from the `content/_global/` directory, you can create `_global/` directory in any section's directory (`content/[section]/_global/`).
 Each section can have global fragments and if there are multiple fragments with the same name, the fragment closest to the page would override the others.

--- a/exampleSite/content/docs/global-variables/content.md
+++ b/exampleSite/content/docs/global-variables/content.md
@@ -85,3 +85,15 @@ Action/clickable URL of the image or the icon.
 *type: string*
 
 If `asset.image` is set, `text` will be used as alternative text (alt-text) of the image.
+
+#### disable
+*type: boolean*
+
+If set to `true`, Syna will not register the fragment. This is useful for drafting fragments.
+
+**NOTE:** `disable` doesn't register the fragment at all. This means you can not remove a global fragment in a specific page by a duplicate disabled fragment. In order to hide a global fragment in a page, use [`hide`](#hide).
+
+#### hide
+*type: boolean*
+
+If set to `true`, Syna will not call the fragment and will hide it. Useful for hiding a global fragment in the page. For more information, please checkout [global fragments]({{< ref "docs/fragments">}}/#global-fragments).

--- a/layouts/partials/helpers/fragments-renderer.html
+++ b/layouts/partials/helpers/fragments-renderer.html
@@ -8,7 +8,7 @@
 {{- range sort ($page_scratch.Get "page_fragments" | default slice) "Params.weight" -}}
   {{/* If a fragment contains a slot variable in it's frontmatter it should not
     be rendered on the page. It would be later handled by the slot helper. */}}
-  {{- if and (not (isset .Params "slot")) (ne .Params.slot "") -}}
+  {{- if and (not (isset .Params "slot")) (ne .Params.slot "") (ne .Params.hide true) -}}
     {{/* Cleanup .Name to be more useful within fragments */}}
     {{- $page_scratch.Set "tmp_name" (cond (eq $page .) .File.BaseFileName (strings.TrimSuffix ".md" (replace .Name "/index.md" ""))) -}}
     {{- if ne $page.Language nil -}}

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -181,7 +181,7 @@
       {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
       {{- if and (not .Params.disabled) (isset .Params "fragment") (not $directory_same_name) -}}
         {{- if or $is_404 (ne .Params.fragment "404") -}}
-          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) -}}
+          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) (ne .Params.hide true) -}}
             {{- $page_scratch.Add "page_config" . -}}
           {{- else if not (where ($page_scratch.Get "page_fragments") ".Name" $name) -}}
             {{- $page_scratch.Add "page_fragments" . -}}

--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -181,7 +181,7 @@
       {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
       {{- if and (not .Params.disabled) (isset .Params "fragment") (not $directory_same_name) -}}
         {{- if or $is_404 (ne .Params.fragment "404") -}}
-          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) (ne .Params.hide true) -}}
+          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) (ne .Params.hide) -}}
             {{- $page_scratch.Add "page_config" . -}}
           {{- else if not (where ($page_scratch.Get "page_fragments") ".Name" $name) -}}
             {{- $page_scratch.Add "page_fragments" . -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new global variable `hide` and tests in the fragment fallthrough dev page for it

**Which issue this PR fixes**:
fixes #731 

**Release note**:
```release-note
- added new global variable `hide` in order to bypass global fragments
```
