### PR TITLE
Fix indenetation of frontmatter's config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,8 +17,8 @@ googleAnalytics = ""
   home = ["HTML", "JSON"]
 
 [frontmatter]
-date = ["date", "lastmod"]
-lastmod = ["lastmod", ":git", "date"]
+  date = ["date", "lastmod"]
+  lastmod = ["lastmod", ":git", "date"]
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
**What this PR does / why we need it**:
Frontmatter's config was not indented properly. Not sure if it was breaking something, hadn't noticed any issues and the problem seem to be quite old at this point.