### PR TITLE
Display correct error on contact page

### DIFF
--- a/layouts/partials/fragments/contact.html
+++ b/layouts/partials/fragments/contact.html
@@ -114,7 +114,7 @@
                     class="form-control text-dark"
                     type="text"
                     data-validation
-                    data-validation-error-msg="{{ .error | default (i18n "contact.defaultButton") }}"
+                    data-validation-error-msg="{{ .error | default (i18n "contact.defaultMessageError") }}"
                     placeholder="{{ with .text }}{{ . | markdownify }}{{ end }}"
                     rows="4"
                     required></textarea>


### PR DESCRIPTION
When a user doesn't write a message on the contact page, the wrong error is displayed: 'Send Message' instead of 'Please enter a message'.