### PR TITLE
Adding pricing red icons css with example.

### DIFF
--- a/assets/styles/_pricing.scss
+++ b/assets/styles/_pricing.scss
@@ -39,6 +39,10 @@
       flex: 1 0 auto;
     }
 
+    .red {
+      color: $red;
+    }
+
     p {
       margin-bottom: 0;
 

--- a/exampleSite/content/fragments/pricing/pricing/plan-1.md
+++ b/exampleSite/content/fragments/pricing/pricing/plan-1.md
@@ -17,4 +17,8 @@ button_url = "#"
 [[features]]
   text = "**Email** support"
   icon = "fas fa-check"
+
+[[features]]
+  text = "Unavailable feature"
+  icon = "fas fa-times-circle red"  
 +++


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:

Adding  the ability to make  the pricing icons red.

![image](https://user-images.githubusercontent.com/5811631/153673975-b3b52f0d-23d0-42fe-ae94-c77caa92600c.png)

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:

This one was achieved by adding a new style to `_pricing.css` called `red`.  I added an example about how to use it inside the exampleSite's `plan-1.md`. I'm not sure if it is the preferred way to achieve this effect but I'm pretty sure it is the less disruptive one.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
- Adding the ability to use red icons inside the pricing features;
```
