### PR TITLE
Restore compatibility with Hugo v0.92.2

### DIFF
--- a/layouts/partials/helpers/fragments.html
+++ b/layouts/partials/helpers/fragments.html
@@ -181,7 +181,7 @@
       {{- $directory_same_name := in ($page_scratch.Get "fragments_directory_name") (printf "%s%s/" $root.File.Dir (replace $name ".md" "")) -}}
       {{- if and (not .Params.disabled) (isset .Params "fragment") (not $directory_same_name) -}}
         {{- if or $is_404 (ne .Params.fragment "404") -}}
-          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) (ne .Params.hide) -}}
+          {{- if and (eq .Params.fragment "config") (not (where ($page_scratch.Get "page_config") ".Name" $name)) (not .Params.hide) -}}
             {{- $page_scratch.Add "page_config" . -}}
           {{- else if not (where ($page_scratch.Get "page_fragments") ".Name" $name) -}}
             {{- $page_scratch.Add "page_fragments" . -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the use of the `ne` template function with only one argument with an equivalent `not`. Hugo enforces this as of v0.92.2, which currently breaks the build of a Syna-based site on the latest versions.

fixes #868 

**Special notes for your reviewer**:
All the other uses of `ne` comparisons I could find, did correctly use 2 arguments.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Restore compatibility with Hugo v0.92.2
```
