### PR TITLE
Fix settings in copyright.html

### DIFF
--- a/layouts/partials/fragments/copyright.html
+++ b/layouts/partials/fragments/copyright.html
@@ -13,7 +13,7 @@
           {{- partial "helpers/text-color.html" (dict "self" $self "light" "white" "dark" "black-50") -}}
         ">
           <div class="row mx-0 mr-lg-auto justify-content-center">
-            {{- with .Params.copyright }}
+            {{- with .Site.Copyright }}
               <div class="col-auto copyright-notice">
                 {{- . | markdownify -}}
               </div>
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      {{- if eq .Params.attribution true }}
+      {{- if eq .Param.attribution true }}
         <div class="col-auto mx-auto">
           <div class="row mx-0 navbar-text text-center
             {{- partial "helpers/text-color.html" (dict "self" $self "light" "white" "dark" "black-50") -}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
This makes it possible to disable attribution with the `attribution` param and allows overriding the copyright message with `copyright`.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:
The settings are already tested for, but were not functional on hugo v0.93.2.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Fix overriding copyright message and disabling attribution footer
```
