### PR TITLE
Fix footer for footer_social

### DIFF
--- a/layouts/partials/fragments/footer.html
+++ b/layouts/partials/fragments/footer.html
@@ -27,7 +27,7 @@
         <div class="row justify-content-left ml-0">
           {{- range sort .Site.Menus.footer_social }}
             <span class="fa-stack fa-2x mt-3 mr-1" title="{{ .Name }}">
-              <a href="{{ .URL | relLangURL }}" class="ignore-color-change
+              <a href="{{ .URL | absLangURL }}" class="ignore-color-change
                 {{- if eq $bg "primary" -}}
                   {{- print " text-dark" -}}
                 {{- end -}}">


### PR DESCRIPTION
Is this a BUG REPORT or FEATURE REQUEST?:
bug

What happened:

On deployment to S3, social media links in the Footer fragment are broken. Instead of linking to the social media page, they create a relative link with the website URL first, followed by the social media page.

What you expected to happen:

Social media links correctly link to the appropriate page

How to reproduce it (as minimally and precisely as possible):

Deploy a website and follow a social media link from the footer fragment (does not occur in local 'hugo server' site)
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Change social media links to be absolute instead of relative
-->
```release-note

```
