### PR TITLE
feat: add parallax on hero

### DIFF
--- a/layouts/partials/fragments/hero.html
+++ b/layouts/partials/fragments/hero.html
@@ -12,6 +12,9 @@
         {{- with .Params.minHeight -}}
           {{- (printf "min-height: %s;" .) | safeCSS -}}
         {{- end -}}
+        {{- if .Params.parallax -}}
+          background-attachment: fixed;
+        {{- end -}}
         background-image:url({{ partial "helpers/image.html" (dict "root" $self "asset" .Params.header) }})"
       class="jumbotron text-center header-image mb-0
         {{- printf " bg-%s" $bg -}}


### PR DESCRIPTION
Add boolean to set the hero background image as fixed to create a parallax scroll effect.

<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Adds a nice parallax effect to the Hero partial

**Which issue this PR fixes** 
partially fixes #814

**Special notes for your reviewer**:
I started learning Hugo and this theme seven hours ago, so I literally don't know what I'm doing.

Just saw that it looked super easy to add a bool to fix the image in the background and get the effect 😇 

It works on my computer ™️ 

**Release note**:
```release-note
 parallax effect to hero partial
```
