### PR TITLE
Fix _internal/google_analytics_async deprecation warning

### DIFF
--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -39,7 +39,7 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- template "_internal/google_analytics_async.html" . -}}
+{{- template "_internal/google_analytics.html" . -}}
 
 {{- if .Site.Params.analytics.piwik -}}
   {{- partial "_analytics/piwik.html" . -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the internal template reference

**Special notes for your reviewer**:
As other themes did https://github.com/google/docsy/pull/1931
PD Last hugo version working for me is 0.122.0

**Release note**:
```release-note
Fix _internal/google_analytics_async deprecation warning
```
