### PR TITLE
Fix deprecated taxonomyTerm

### DIFF
--- a/exampleSite/config-dev.toml
+++ b/exampleSite/config-dev.toml
@@ -7,7 +7,7 @@ theme = "syna"
 themesDir = "../.."
 enableGitInfo = true
 version = "0.17.4"
-disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]
+disableKinds = ["RSS", "taxonomy"]
 
 RelativeURLs = true
 CanonifyURLs = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,7 +7,7 @@ theme = "syna"
 themesDir = "../.."
 enableGitInfo = true
 version = "0.17.4"
-disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]
+disableKinds = ["RSS", "taxonomy"]
 ignorefiles = [ "content/dev/.*" ]
 
 # Google Analytics tracking


### PR DESCRIPTION
**What this PR does / why we need it**:
Deletes the deprecated term in the exampleSite

**Release note**:
```release-note
Fix deprecated taxonomyTerm in exampleSite
```
