### PR TITLE
Update baseurl in config.toml to use the correct site URL

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,5 @@
 # Site settings
-baseurl = "/"
+baseurl = "https://example.org/"
 languageCode = "en-us"
 defaultContentLanguage = "en"
 title = "Okkur - Syna"


### PR DESCRIPTION
This pull request updates the base URL configuration for the example site to use a full URL instead of a relative path.

* [`exampleSite/config.toml`](diffhunk://#diff-a22ce72f559279e2b268c61544e9e67d3bec733d98c878c79ea381623539069cL2-R2): Changed the `baseurl` setting from `"/"` to `"https://example.org/"` to ensure the site uses an absolute URL for resource links.

fixes #893 